### PR TITLE
Golang 1.16 issue

### DIFF
--- a/boilerplate/backend/go-http/go.mod
+++ b/boilerplate/backend/go-http/go.mod
@@ -1,25 +1,7 @@
 module go-http
 
-go 1.17
+go 1.16
 
 require (
 	github.com/supertokens/supertokens-golang v0.9.7
-	github.com/MicahParks/keyfunc v1.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/derekstavis/go-qs v0.0.0-20180720192143-9eef69e6c4e7 // indirect
-	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/protobuf v1.3.2 // indirect
-	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
-	github.com/nyaruka/phonenumbers v1.0.73 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
-	github.com/twilio/twilio-go v0.26.0 // indirect
-	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
-	gopkg.in/h2non/gock.v1 v1.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/boilerplate/backend/go-http/go.mod
+++ b/boilerplate/backend/go-http/go.mod
@@ -1,7 +1,0 @@
-module go-http
-
-go 1.16
-
-require (
-	github.com/supertokens/supertokens-golang v0.9.7
-)

--- a/lib/build/config.js
+++ b/lib/build/config.js
@@ -160,7 +160,7 @@ export async function getBackendOptions(userArguments) {
                 configFiles: "/config",
             },
             script: {
-                setup: ["go get -u github.com/supertokens/supertokens-golang && go get ./... && go mod tidy"],
+                setup: ["go mod init 'go-http' && go get ./... && go mod tidy"],
                 run: ["go run ."],
             },
         },

--- a/lib/ts/config.ts
+++ b/lib/ts/config.ts
@@ -166,7 +166,7 @@ export async function getBackendOptions(userArguments: UserFlags): Promise<Quest
                 configFiles: "/config",
             },
             script: {
-                setup: ["go get -u github.com/supertokens/supertokens-golang && go get ./... && go mod tidy"],
+                setup: ["go mod init 'go-http' && go get ./... && go mod tidy"],
                 run: ["go run ."],
             },
         },


### PR DESCRIPTION
The command was failing with golang version 1.16 because the boilerplate had version 1.17. Our golang SDK officially supports 1.16.

Fix:
Removed go.mod from bolierplate and added go init and go get commands to figure out the version based on the installed version of go.