### PR TITLE
fix: Fix issue with peer dependencies in older npm versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.0.24] - 2023-02-10
+
+-   Fixes an issue where peer dependencies would not get installed correctly for older versions of npm
+
 ## [0.0.23] - 2023-01-06
 
 -   Fixes an issue with golang apps failing to install dependencies

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -105,6 +105,50 @@ function getPackageJsonString(input) {
     }
     `;
 }
+async function performAdditionalSetupForFrontendIfNeeded(selectedFrontend, folderName, userArguments) {
+    /**
+     * For React and Next frontend we check if supertokens-web-js has been installed correctly and manually
+     * install it if it is missing. This is because old versions of npm sometimes does not install
+     * peer dependencies when running `npm install`
+     *
+     * Note we only do this if the package manager is npm and not for yarn
+     */
+    if ((selectedFrontend.value === "react" || selectedFrontend.value === "next") && userArguments.manager !== "yarn") {
+        const sourceFolder = selectedFrontend.value === "react" ? `${folderName}/frontend` : `${folderName}`;
+        if (!fs.existsSync(`${sourceFolder}/node_modules/supertokens-web-js`)) {
+            let result = await new Promise((res) => {
+                let stderr = [];
+                const additionalSetup = exec(`cd ${sourceFolder} && npm i supertokens-web-js`);
+                additionalSetup.on("exit", (code) => {
+                    const errorString = stderr.join("\n");
+                    res({
+                        code,
+                        error: errorString.length === 0 ? undefined : errorString,
+                    });
+                });
+                additionalSetup.stderr?.on("data", (data) => {
+                    // Record any messages printed as errors
+                    stderr.push(data.toString());
+                });
+                additionalSetup.stdout?.on("data", (data) => {
+                    /**
+                     * Record any messages printed as errors, we do this for stdout
+                     * as well because some scripts use the output stream for errors
+                     * too (npm for example) while others use stderr only
+                     *
+                     * This means that we will output everything if the script exits with
+                     * non zero
+                     */
+                    stderr.push(data.toString());
+                });
+            });
+            if (result.code !== 0) {
+                const error = result.error !== undefined ? result.error : defaultSetupErrorString;
+                throw new Error(error);
+            }
+        }
+    }
+}
 async function setupFrontendBackendApp(answers, folderName, locations, userArguments, spinner) {
     const frontendFolderName = locations.frontend
         .split("/")
@@ -218,6 +262,7 @@ async function setupFrontendBackendApp(answers, folderName, locations, userArgum
         const error = frontendSetupResult.error !== undefined ? frontendSetupResult.error : defaultSetupErrorString;
         throw new Error(error);
     }
+    await performAdditionalSetupForFrontendIfNeeded(selectedFrontend, folderName, userArguments);
     spinner.text = "Installing backend dependencies";
     const backendSetup = new Promise((res) => {
         let stderr = [];

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -107,45 +107,52 @@ function getPackageJsonString(input) {
 }
 async function performAdditionalSetupForFrontendIfNeeded(selectedFrontend, folderName, userArguments) {
     /**
-     * For React and Next frontend we check if supertokens-web-js has been installed correctly and manually
+     * For all frontends we check if supertokens-web-js has been installed correctly and manually
      * install it if it is missing. This is because old versions of npm sometimes does not install
      * peer dependencies when running `npm install`
-     *
-     * Note we only do this if the package manager is npm and not for yarn
      */
-    if ((selectedFrontend.value === "react" || selectedFrontend.value === "next") && userArguments.manager !== "yarn") {
-        const sourceFolder = selectedFrontend.value === "react" ? `${folderName}/frontend` : `${folderName}`;
-        if (!fs.existsSync(`${sourceFolder}/node_modules/supertokens-web-js`)) {
-            let result = await new Promise((res) => {
-                let stderr = [];
-                const additionalSetup = exec(`cd ${sourceFolder} && npm i supertokens-web-js`);
-                additionalSetup.on("exit", (code) => {
-                    const errorString = stderr.join("\n");
-                    res({
-                        code,
-                        error: errorString.length === 0 ? undefined : errorString,
-                    });
-                });
-                additionalSetup.stderr?.on("data", (data) => {
-                    // Record any messages printed as errors
-                    stderr.push(data.toString());
-                });
-                additionalSetup.stdout?.on("data", (data) => {
-                    /**
-                     * Record any messages printed as errors, we do this for stdout
-                     * as well because some scripts use the output stream for errors
-                     * too (npm for example) while others use stderr only
-                     *
-                     * This means that we will output everything if the script exits with
-                     * non zero
-                     */
-                    stderr.push(data.toString());
+    const sourceFolder = selectedFrontend.value !== "next" ? `${folderName}/frontend` : `${folderName}`;
+    // If this is false then the project does not use the react SDK
+    const doesUseAuthReact = fs.existsSync(`${sourceFolder}/node_modules/supertokens-auth-react`);
+    const doesWebJsExist = () => {
+        const doesExistInNodeModules = fs.existsSync(`${sourceFolder}/node_modules/supertokens-web-js`);
+        const doesExistInAuthReact = fs.existsSync(
+            `${sourceFolder}/node_modules/supertokens-auth-react/node_modules/supertokens-web-js`
+        );
+        return doesExistInAuthReact || doesExistInNodeModules;
+    };
+    // We only check for web-js being present if the project uses the auth react SDK
+    if (doesUseAuthReact && !doesWebJsExist()) {
+        const installPrefix = userArguments.manager === "yarn" ? "yarn add" : "npm i";
+        let result = await new Promise((res) => {
+            let stderr = [];
+            const additionalSetup = exec(`cd ${sourceFolder} && ${installPrefix} supertokens-web-js`);
+            additionalSetup.on("exit", (code) => {
+                const errorString = stderr.join("\n");
+                res({
+                    code,
+                    error: errorString.length === 0 ? undefined : errorString,
                 });
             });
-            if (result.code !== 0) {
-                const error = result.error !== undefined ? result.error : defaultSetupErrorString;
-                throw new Error(error);
-            }
+            additionalSetup.stderr?.on("data", (data) => {
+                // Record any messages printed as errors
+                stderr.push(data.toString());
+            });
+            additionalSetup.stdout?.on("data", (data) => {
+                /**
+                 * Record any messages printed as errors, we do this for stdout
+                 * as well because some scripts use the output stream for errors
+                 * too (npm for example) while others use stderr only
+                 *
+                 * This means that we will output everything if the script exits with
+                 * non zero
+                 */
+                stderr.push(data.toString());
+            });
+        });
+        if (result.code !== 0) {
+            const error = result.error !== undefined ? result.error : defaultSetupErrorString;
+            throw new Error(error);
         }
     }
 }

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -111,7 +111,7 @@ async function performAdditionalSetupForFrontendIfNeeded(selectedFrontend, folde
      * install it if it is missing. This is because old versions of npm sometimes does not install
      * peer dependencies when running `npm install`
      */
-    const sourceFolder = selectedFrontend.value !== "next" ? `${folderName}/frontend` : `${folderName}`;
+    const sourceFolder = selectedFrontend.isFullStack !== true ? `${folderName}/frontend` : `${folderName}`;
     // If this is false then the project does not use the react SDK
     const doesUseAuthReact = fs.existsSync(`${sourceFolder}/node_modules/supertokens-auth-react`);
     const doesWebJsExist = () => {

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -438,6 +438,7 @@ async function setupFullstack(answers, folderName, userArguments, spinner) {
         const error = setupResultObj.error !== undefined ? setupResultObj.error : defaultSetupErrorString;
         throw new Error(error);
     }
+    await performAdditionalSetupForFrontendIfNeeded(selectedFullStack, folderName, userArguments);
 }
 export async function setupProject(locations, folderName, answers, userArguments, spinner) {
     const isFullStack = locations.frontend === locations.backend;

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -1,1 +1,1 @@
-export const package_version = "0.0.23";
+export const package_version = "0.0.24";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -148,7 +148,7 @@ async function performAdditionalSetupForFrontendIfNeeded(
      * install it if it is missing. This is because old versions of npm sometimes does not install
      * peer dependencies when running `npm install`
      */
-    const sourceFolder = selectedFrontend.value !== "next" ? `${folderName}/frontend` : `${folderName}`;
+    const sourceFolder = selectedFrontend.isFullStack !== true ? `${folderName}/frontend` : `${folderName}`;
 
     // If this is false then the project does not use the react SDK
     const doesUseAuthReact = fs.existsSync(`${sourceFolder}/node_modules/supertokens-auth-react`);

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -552,6 +552,8 @@ async function setupFullstack(answers: Answers, folderName: string, userArgument
 
         throw new Error(error);
     }
+
+    await performAdditionalSetupForFrontendIfNeeded(selectedFullStack, folderName, userArguments);
 }
 
 export async function setupProject(

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -1,1 +1,1 @@
-export const package_version = "0.0.23";
+export const package_version = "0.0.24";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-supertokens-app",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "create-supertokens-app",
-            "version": "0.0.23",
+            "version": "0.0.24",
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-supertokens-app",
     "type": "module",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Older npm versions would have an issue where supertokens-web-js would not get installed because it was listed as a peer dependency.

This PR changes the main logic of the tool to check if supertokens-web-js exists in the node modules of the generated project (regardless of node/npm versions) and installs it separately if it doesnt.