### PR TITLE
fix: Allow multitenancy to be used as a command line flag

### DIFF
--- a/.github/PULL_REQUEST_TEPLATE.md
+++ b/.github/PULL_REQUEST_TEPLATE.md
@@ -1,0 +1,34 @@
+## Summary of change
+
+A brief description of what this PR is about
+
+## Related issues
+
+-   Link to issue1 here
+-   Link to issue1 here
+
+## Test plan
+
+-   [ ] If added a new boilerplate
+    -   I tested the new boilerplate by running the CLI locally
+    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
+-   [ ] If added a new recipe, frontend or backend
+    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)
+
+## Checklist for important updates
+
+-   [ ] Changelog has been updated
+-   [ ] Changes to the version if needed
+    -   In `package.json`
+    -   In `package-lock.json`
+    -   In `lib/ts/version.ts`
+-   [ ] Had run `npm run build-pretty`
+-   [ ] Had installed and ran the pre-commit hook
+-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
+-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
+-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required
+
+## Remaining TODOs for this PR
+
+-   [ ] Item1
+-   [ ] Item2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.0.34] - 2023-07-27
+
+-   Fixes an issue where multitenancy could not be used as a command line flag
+
 ## [0.0.33] - 2023-07-26
 
 -   Adds sample apps for Multitenancy with Express and Nest on the backend, and React and Next on the frontend.

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -117,10 +117,12 @@ async function run() {
             ) {
                 errorPlaceholder = "Python";
             }
-            const errorMessage = `create-supertokens-app does not support Multitenancy for ${errorPlaceholder} yet. You can refer to our docs to set it up manually: https://supertokens.com/docs/multitenancy/introduction`;
-            const error = new Error(errorMessage);
-            error.skipGithubLink = true;
-            throw error;
+            if (errorPlaceholder !== "") {
+                const errorMessage = `create-supertokens-app does not support Multitenancy for ${errorPlaceholder} yet. You can refer to our docs to set it up manually: https://supertokens.com/docs/multitenancy/introduction`;
+                const error = new Error(errorMessage);
+                error.skipGithubLink = true;
+                throw error;
+            }
         }
         console.log("");
         const downloadSpinner = Ora({

--- a/lib/build/types.js
+++ b/lib/build/types.js
@@ -4,6 +4,7 @@ export const allRecipes = [
     "passwordless",
     "thirdpartypasswordless",
     "thirdparty",
+    "multitenancy",
 ];
 export function isValidRecipeName(recipe) {
     if (allRecipes.includes(recipe)) {

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -1,1 +1,1 @@
-export const package_version = "0.0.33";
+export const package_version = "0.0.34";

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -134,10 +134,12 @@ async function run() {
                 errorPlaceholder = "Python";
             }
 
-            const errorMessage = `create-supertokens-app does not support Multitenancy for ${errorPlaceholder} yet. You can refer to our docs to set it up manually: https://supertokens.com/docs/multitenancy/introduction`;
-            const error = new Error(errorMessage);
-            (error as any).skipGithubLink = true;
-            throw error;
+            if (errorPlaceholder !== "") {
+                const errorMessage = `create-supertokens-app does not support Multitenancy for ${errorPlaceholder} yet. You can refer to our docs to set it up manually: https://supertokens.com/docs/multitenancy/introduction`;
+                const error = new Error(errorMessage);
+                (error as any).skipGithubLink = true;
+                throw error;
+            }
         }
 
         console.log("");

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -3,7 +3,8 @@ export type Recipe =
     | "thirdpartyemailpassword"
     | "passwordless"
     | "thirdpartypasswordless"
-    | "thirdparty";
+    | "thirdparty"
+    | "multitenancy";
 
 export const allRecipes: Recipe[] = [
     "emailpassword",
@@ -11,6 +12,7 @@ export const allRecipes: Recipe[] = [
     "passwordless",
     "thirdpartypasswordless",
     "thirdparty",
+    "multitenancy",
 ];
 
 export function isValidRecipeName(recipe: string): recipe is Recipe {
@@ -28,6 +30,10 @@ export type SupportedFrontends =
     | "angular-prebuilt"
     | "vue-prebuilt"
     | "capacitor"
+    /*
+     * react-multitenancy is intentionally not added to allFrontends because the user is not expected to use this
+     * as an option directly and should not be aware of it.
+     */
     | "react-multitenancy";
 
 export const allFrontends: {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -1,1 +1,1 @@
-export const package_version = "0.0.33";
+export const package_version = "0.0.34";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-supertokens-app",
-    "version": "0.0.33",
+    "version": "0.0.34",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "create-supertokens-app",
-            "version": "0.0.33",
+            "version": "0.0.34",
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-supertokens-app",
     "type": "module",
-    "version": "0.0.33",
+    "version": "0.0.34",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Allows multitenancy to be used as a command line flag

## Related issues

- 

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [x] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] ...
