### PR TITLE
fix: Fix downloading additional files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.0.34] - 2023-08-16
+
+-   Fixes an issue where the CLI would not download additional files when not using the multitenancy recipe
+
 ## [0.0.34] - 2023-07-27
 
 -   Fixes an issue where multitenancy could not be used as a command line flag

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -92,10 +92,18 @@ export async function downloadApp(locations, folderName) {
                 strip: isFullStack ? 4 : 3,
                 strict: true,
                 filter: (path, _) => {
-                    if (path.includes(locations.frontend)) {
+                    let frontendLocation = locations.frontend;
+                    let backendLocation = locations.backend;
+                    if (!frontendLocation.endsWith("/")) {
+                        frontendLocation += "/";
+                    }
+                    if (!backendLocation.endsWith("/")) {
+                        backendLocation += "/";
+                    }
+                    if (path.includes(frontendLocation)) {
                         return true;
                     }
-                    if (path.includes(locations.backend)) {
+                    if (path.includes(backendLocation)) {
                         return true;
                     }
                     return false;

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -1,1 +1,1 @@
-export const package_version = "0.0.34";
+export const package_version = "0.0.35";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -119,11 +119,22 @@ export async function downloadApp(locations: DownloadLocations, folderName: stri
                 strip: isFullStack ? 4 : 3,
                 strict: true,
                 filter: (path, _) => {
-                    if (path.includes(locations.frontend)) {
+                    let frontendLocation = locations.frontend;
+                    let backendLocation = locations.backend;
+
+                    if (!frontendLocation.endsWith("/")) {
+                        frontendLocation += "/";
+                    }
+
+                    if (!backendLocation.endsWith("/")) {
+                        backendLocation += "/";
+                    }
+
+                    if (path.includes(frontendLocation)) {
                         return true;
                     }
 
-                    if (path.includes(locations.backend)) {
+                    if (path.includes(backendLocation)) {
                         return true;
                     }
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -1,1 +1,1 @@
-export const package_version = "0.0.34";
+export const package_version = "0.0.35";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-supertokens-app",
-    "version": "0.0.34",
+    "version": "0.0.35",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "create-supertokens-app",
-            "version": "0.0.34",
+            "version": "0.0.35",
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-supertokens-app",
     "type": "module",
-    "version": "0.0.34",
+    "version": "0.0.35",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Fixes an issue where multitenancy files were downloaded even when not using the recipe

## Related issues

- ...

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] ...
