### PR TITLE
feat: Add Bun support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.0.37] - 2023-08-24
+
+-   Adds bun support when running the CLI. To use bun when using this tool use the additional `--manager=bun` flag.
+
 ## [0.0.36] - 2023-08-24
 
 -   Adds support for multitenancy to golang and python

--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@
 
 ## Usage
 
+### Using npm
+
 Run the tool using the following command
 
 `npx create-supertokens-app`
+
+### Using Bun
+
+Run the tool using the following command
+
+`bun create supertokens-app@latest --manager=bun`
 
 You can then select the tech stack that is relevant to you.
 

--- a/lib/build/types.js
+++ b/lib/build/types.js
@@ -72,7 +72,7 @@ export function isValidBackend(backend) {
     }
     return false;
 }
-export const allPackageManagers = ["npm", "yarn"];
+export const allPackageManagers = ["npm", "yarn", "bun"];
 export function isValidPackageManager(manager) {
     if (allPackageManagers.includes(manager)) {
         return true;

--- a/lib/build/userArgumentUtils.js
+++ b/lib/build/userArgumentUtils.js
@@ -97,6 +97,9 @@ export async function getPackageManagerCommand(userArguments) {
     if (userArguments.manager === "yarn") {
         return "yarn";
     }
+    if (userArguments.manager === "bun") {
+        return "bun";
+    }
     return "npm";
 }
 export function getShouldAutoStartFromArgs(userArguments) {

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -1,1 +1,1 @@
-export const package_version = "0.0.36";
+export const package_version = "0.0.37";

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -200,9 +200,9 @@ export type DownloadLocations = {
     isExternalApp?: boolean;
 };
 
-export type SupportedPackageManagers = "npm" | "yarn";
+export type SupportedPackageManagers = "npm" | "yarn" | "bun";
 
-export const allPackageManagers: SupportedPackageManagers[] = ["npm", "yarn"];
+export const allPackageManagers: SupportedPackageManagers[] = ["npm", "yarn", "bun"];
 
 export function isValidPackageManager(manager: string): manager is SupportedPackageManagers {
     if (allPackageManagers.includes(manager as SupportedPackageManagers)) {

--- a/lib/ts/userArgumentUtils.ts
+++ b/lib/ts/userArgumentUtils.ts
@@ -130,6 +130,10 @@ export async function getPackageManagerCommand(userArguments: UserFlags): Promis
         return "yarn";
     }
 
+    if (userArguments.manager === "bun") {
+        return "bun";
+    }
+
     return "npm";
 }
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -1,1 +1,1 @@
-export const package_version = "0.0.36";
+export const package_version = "0.0.37";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-supertokens-app",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "create-supertokens-app",
-            "version": "0.0.36",
+            "version": "0.0.37",
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-supertokens-app",
     "type": "module",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Allows users to use Bun as the package manager

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] ...
