### PR TITLE
fix: update dependencies

### DIFF
--- a/boilerplate/fullstack/next/package.json
+++ b/boilerplate/fullstack/next/package.json
@@ -10,7 +10,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "supertokens-auth-react": "latest",
-        "supertokens-node": "latest"
+        "supertokens-node": "latest",
+        "supertokens-web-js": "latest"
     },
     "devDependencies": {
         "@types/react": "18.0.17",


### PR DESCRIPTION
Updates the dependencies to include `supertokens-web-js`, was running into an error without it when running locally.