### PR TITLE
fix: removed hardcoded dependencies for framework versions

### DIFF
--- a/boilerplate/backend/python-drf/requirements.txt
+++ b/boilerplate/backend/python-drf/requirements.txt
@@ -1,4 +1,2 @@
-Django==3.2.12
-djangorestframework==3.14.0
-supertokens-python
-django-cors-headers==3.12.0
+djangorestframework
+supertokens-python[django]

--- a/boilerplate/backend/python-fastapi/requirements.txt
+++ b/boilerplate/backend/python-fastapi/requirements.txt
@@ -1,3 +1,1 @@
-fastapi==0.63.0
-uvicorn==0.16.0
-supertokens-python
+supertokens-python[fastapi]

--- a/boilerplate/backend/python-flask/requirements.txt
+++ b/boilerplate/backend/python-flask/requirements.txt
@@ -1,4 +1,1 @@
-flask==2.0.1
-flask_cors==3.0.10
-python-dotenv==0.19.2
-supertokens-python
+supertokens-python[flask]


### PR DESCRIPTION
## Summary of change

Removed hardcoded dependencies for framework versions

## Related issues



## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR


