### PR TITLE
chore: add userroles recipe to node boilerplate

### DIFF
--- a/boilerplate/backend/nest/config/emailpassword.ts
+++ b/boilerplate/backend/nest/config/emailpassword.ts
@@ -1,6 +1,7 @@
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -17,4 +18,5 @@ export const recipeList = [
   EmailPassword.init(),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/nest/config/multitenancy.ts
+++ b/boilerplate/backend/nest/config/multitenancy.ts
@@ -2,6 +2,7 @@ import ThirdPartyEmailPassword from 'supertokens-node/recipe/thirdpartyemailpass
 import ThirdPartyPasswordless from 'supertokens-node/recipe/thirdpartypasswordless';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -22,4 +23,5 @@ export const recipeList = [
   }),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/nest/config/passwordless.ts
+++ b/boilerplate/backend/nest/config/passwordless.ts
@@ -1,6 +1,7 @@
 import Passwordless from 'supertokens-node/recipe/passwordless';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -20,4 +21,5 @@ export const recipeList = [
   }),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/nest/config/thirdparty.ts
+++ b/boilerplate/backend/nest/config/thirdparty.ts
@@ -1,6 +1,7 @@
 import ThirdParty from 'supertokens-node/recipe/thirdparty';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -75,4 +76,5 @@ export const recipeList = [
   }),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/nest/config/thirdpartyemailpassword.ts
+++ b/boilerplate/backend/nest/config/thirdpartyemailpassword.ts
@@ -1,6 +1,7 @@
 import ThirdPartyEmailPassword from 'supertokens-node/recipe/thirdpartyemailpassword';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -73,4 +74,5 @@ export const recipeList = [
   }),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/nest/config/thirdpartypasswordless.ts
+++ b/boilerplate/backend/nest/config/thirdpartypasswordless.ts
@@ -1,6 +1,7 @@
 import ThirdPartyPasswordless from 'supertokens-node/recipe/thirdpartypasswordless';
 import Session from 'supertokens-node/recipe/session';
 import Dashboard from 'supertokens-node/recipe/dashboard';
+import UserRoles from 'supertokens-node/recipe/userroles';
 
 export const appInfo = {
   // Learn more about this on https://supertokens.com/docs/thirdpartypasswordless/appInfo
@@ -75,4 +76,5 @@ export const recipeList = [
   }),
   Session.init(),
   Dashboard.init(),
+  UserRoles.init(),
 ];

--- a/boilerplate/backend/node-express/config/emailpassword.ts
+++ b/boilerplate/backend/node-express/config/emailpassword.ts
@@ -2,6 +2,7 @@ import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -27,5 +28,5 @@ export const SuperTokensConfig: TypeInput = {
     },
     // recipeList contains all the modules that you want to
     // use from SuperTokens. See the full list here: https://supertokens.com/docs/guides
-    recipeList: [EmailPassword.init(), Session.init(), Dashboard.init()],
+    recipeList: [EmailPassword.init(), Session.init(), Dashboard.init(), UserRoles.init()],
 };

--- a/boilerplate/backend/node-express/config/multitenancy.ts
+++ b/boilerplate/backend/node-express/config/multitenancy.ts
@@ -3,6 +3,7 @@ import ThirdPartyPasswordless from "supertokens-node/recipe/thirdpartypasswordle
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -36,5 +37,6 @@ export const SuperTokensConfig: TypeInput = {
         }),
         Session.init(),
         Dashboard.init(),
+        UserRoles.init(),
     ],
 };

--- a/boilerplate/backend/node-express/config/passwordless.ts
+++ b/boilerplate/backend/node-express/config/passwordless.ts
@@ -2,6 +2,7 @@ import Passwordless from "supertokens-node/recipe/passwordless";
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -34,5 +35,6 @@ export const SuperTokensConfig: TypeInput = {
         }),
         Session.init(),
         Dashboard.init(),
+        UserRoles.init(),
     ],
 };

--- a/boilerplate/backend/node-express/config/thirdparty.ts
+++ b/boilerplate/backend/node-express/config/thirdparty.ts
@@ -2,6 +2,7 @@ import ThirdParty from "supertokens-node/recipe/thirdparty";
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -88,5 +89,6 @@ export const SuperTokensConfig: TypeInput = {
         }),
         Session.init(),
         Dashboard.init(),
+        UserRoles.init(),
     ],
 };

--- a/boilerplate/backend/node-express/config/thirdpartyemailpassword.ts
+++ b/boilerplate/backend/node-express/config/thirdpartyemailpassword.ts
@@ -2,6 +2,7 @@ import ThirdPartyEmailPassword from "supertokens-node/recipe/thirdpartyemailpass
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -85,5 +86,6 @@ export const SuperTokensConfig: TypeInput = {
         }),
         Session.init(),
         Dashboard.init(),
+        UserRoles.init(),
     ],
 };

--- a/boilerplate/backend/node-express/config/thirdpartypasswordless.ts
+++ b/boilerplate/backend/node-express/config/thirdpartypasswordless.ts
@@ -2,6 +2,7 @@ import ThirdPartyPasswordless from "supertokens-node/recipe/thirdpartypasswordle
 import Session from "supertokens-node/recipe/session";
 import { TypeInput } from "supertokens-node/types";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 
 export function getApiDomain() {
     const apiPort = process.env.REACT_APP_API_PORT || 3001;
@@ -87,5 +88,6 @@ export const SuperTokensConfig: TypeInput = {
         }),
         Session.init(),
         Dashboard.init(),
+        UserRoles.init(),
     ],
 };

--- a/boilerplate/fullstack/next-app-dir-multitenancy/app/config/backend/multitenancy.ts
+++ b/boilerplate/fullstack/next-app-dir-multitenancy/app/config/backend/multitenancy.ts
@@ -2,6 +2,7 @@ import ThirdPartyEmailPasswordNode from "supertokens-node/recipe/thirdpartyemail
 import ThirdPartyPasswordlessNode from "supertokens-node/recipe/thirdpartypasswordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -23,6 +24,7 @@ export let backendConfig = (): TypeInput => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
         framework: "custom",

--- a/boilerplate/fullstack/next-app-dir/app/config/backend/emailpassword.ts
+++ b/boilerplate/fullstack/next-app-dir/app/config/backend/emailpassword.ts
@@ -1,6 +1,7 @@
 import EmailPasswordNode from "supertokens-node/recipe/emailpassword";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -14,7 +15,7 @@ export let backendConfig = (): TypeInput => {
         appInfo,
         // recipeList contains all the modules that you want to
         // use from SuperTokens. See the full list here: https://supertokens.com/docs/guides
-        recipeList: [EmailPasswordNode.init(), SessionNode.init(), Dashboard.init()],
+        recipeList: [EmailPasswordNode.init(), SessionNode.init(), Dashboard.init(), UserRoles.init()],
         isInServerlessEnv: true,
         framework: "custom",
     };

--- a/boilerplate/fullstack/next-app-dir/app/config/backend/passwordless.ts
+++ b/boilerplate/fullstack/next-app-dir/app/config/backend/passwordless.ts
@@ -1,6 +1,7 @@
 import PasswordlessNode from "supertokens-node/recipe/passwordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -21,6 +22,7 @@ export let backendConfig = (): TypeInput => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
         framework: "custom",

--- a/boilerplate/fullstack/next-app-dir/app/config/backend/thirdparty.ts
+++ b/boilerplate/fullstack/next-app-dir/app/config/backend/thirdparty.ts
@@ -1,6 +1,7 @@
 import ThirdPartyNode from "supertokens-node/recipe/thirdparty";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -75,6 +76,7 @@ export let backendConfig = (): TypeInput => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
         framework: "custom",

--- a/boilerplate/fullstack/next-app-dir/app/config/backend/thirdpartyemailpassword.ts
+++ b/boilerplate/fullstack/next-app-dir/app/config/backend/thirdpartyemailpassword.ts
@@ -1,6 +1,7 @@
 import ThirdPartyEmailPasswordNode from "supertokens-node/recipe/thirdpartyemailpassword";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -73,6 +74,7 @@ export let backendConfig = (): TypeInput => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
         framework: "custom",

--- a/boilerplate/fullstack/next-app-dir/app/config/backend/thirdpartypasswordless.ts
+++ b/boilerplate/fullstack/next-app-dir/app/config/backend/thirdpartypasswordless.ts
@@ -1,6 +1,7 @@
 import ThirdPartyPasswordlessNode from "supertokens-node/recipe/thirdpartypasswordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { TypeInput } from "supertokens-node/types";
 import SuperTokens from "supertokens-node";
@@ -75,6 +76,7 @@ export let backendConfig = (): TypeInput => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
         framework: "custom",

--- a/boilerplate/fullstack/next-multitenancy/config/backend/multitenancy.ts
+++ b/boilerplate/fullstack/next-multitenancy/config/backend/multitenancy.ts
@@ -2,6 +2,7 @@ import ThirdPartyEmailPasswordNode from "supertokens-node/recipe/thirdpartyemail
 import ThirdPartyPasswordlessNode from "supertokens-node/recipe/thirdpartypasswordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
 
@@ -23,6 +24,7 @@ export let backendConfig = (): AuthConfig => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
     };

--- a/boilerplate/fullstack/next/config/backend/emailpassword.ts
+++ b/boilerplate/fullstack/next/config/backend/emailpassword.ts
@@ -1,6 +1,7 @@
 import EmailPasswordNode from "supertokens-node/recipe/emailpassword";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
 
@@ -14,7 +15,7 @@ export let backendConfig = (): AuthConfig => {
         appInfo,
         // recipeList contains all the modules that you want to
         // use from SuperTokens. See the full list here: https://supertokens.com/docs/guides
-        recipeList: [EmailPasswordNode.init(), SessionNode.init(), Dashboard.init()],
+        recipeList: [EmailPasswordNode.init(), SessionNode.init(), Dashboard.init(), UserRoles.init()],
         isInServerlessEnv: true,
     };
 };

--- a/boilerplate/fullstack/next/config/backend/passwordless.ts
+++ b/boilerplate/fullstack/next/config/backend/passwordless.ts
@@ -1,6 +1,7 @@
 import PasswordlessNode from "supertokens-node/recipe/passwordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
 
@@ -21,6 +22,7 @@ export let backendConfig = (): AuthConfig => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
     };

--- a/boilerplate/fullstack/next/config/backend/thirdparty.ts
+++ b/boilerplate/fullstack/next/config/backend/thirdparty.ts
@@ -1,5 +1,6 @@
 import ThirdPartyNode from "supertokens-node/recipe/thirdparty";
 import SessionNode from "supertokens-node/recipe/session";
+import UserRoles from "supertokens-node/recipe/userroles";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
@@ -75,6 +76,7 @@ export let backendConfig = (): AuthConfig => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
     };

--- a/boilerplate/fullstack/next/config/backend/thirdpartyemailpassword.ts
+++ b/boilerplate/fullstack/next/config/backend/thirdpartyemailpassword.ts
@@ -1,6 +1,7 @@
 import ThirdPartyEmailPasswordNode from "supertokens-node/recipe/thirdpartyemailpassword";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
 
@@ -73,6 +74,7 @@ export let backendConfig = (): AuthConfig => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
     };

--- a/boilerplate/fullstack/next/config/backend/thirdpartypasswordless.ts
+++ b/boilerplate/fullstack/next/config/backend/thirdpartypasswordless.ts
@@ -1,6 +1,7 @@
 import ThirdPartyPasswordlessNode from "supertokens-node/recipe/thirdpartypasswordless";
 import SessionNode from "supertokens-node/recipe/session";
 import Dashboard from "supertokens-node/recipe/dashboard";
+import UserRoles from "supertokens-node/recipe/userroles";
 import { appInfo } from "./appInfo";
 import { AuthConfig } from "../interfaces";
 
@@ -75,6 +76,7 @@ export let backendConfig = (): AuthConfig => {
             }),
             SessionNode.init(),
             Dashboard.init(),
+            UserRoles.init(),
         ],
         isInServerlessEnv: true,
     };


### PR DESCRIPTION
## Summary of change

Adds UserRoles init snippet to the backend node-express config boilerplate.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [X] Had run `npm run build-pretty`
-   [X] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
