### PR TITLE
fix: remove unnecessary dev dependencies from next.js examples

### DIFF
--- a/boilerplate/fullstack/next-app-dir-multitenancy/package.json
+++ b/boilerplate/fullstack/next-app-dir-multitenancy/package.json
@@ -22,8 +22,6 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "13.5.4",
-        "i": "^0.3.7",
-        "npm": "^10.2.0",
         "typescript": "^5"
     }
 }

--- a/boilerplate/fullstack/next-app-dir/package.json
+++ b/boilerplate/fullstack/next-app-dir/package.json
@@ -22,8 +22,6 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "13.5.4",
-        "i": "^0.3.7",
-        "npm": "^10.2.0",
         "typescript": "^5"
     }
 }


### PR DESCRIPTION
## Summary of change

This PR removed `i` and `npm` from two of the next.js examples. These probably ended up there by mistake.

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
