### PR TITLE
fix: Update NestJS AuthGuard to use getSession

### DIFF
--- a/boilerplate/backend/nest/src/app.controller.ts
+++ b/boilerplate/backend/nest/src/app.controller.ts
@@ -16,7 +16,9 @@ export class AppController {
 
   @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  getSessionInformation(@Session() session: SessionContainer): any {
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
     return {
       sessionHandle: session.getHandle(),
       userId: session.getUserId(),

--- a/boilerplate/backend/nest/src/auth/auth.filter.ts
+++ b/boilerplate/backend/nest/src/auth/auth.filter.ts
@@ -16,9 +16,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,


### PR DESCRIPTION
## Summary of change

This PR updates the NestJS AuthGuard to use getSession instead of verifySession.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required
