### PR TITLE
fix: Remove getSession usage from SSR

### DIFF
--- a/boilerplate/backend/go-http/config/thirdpartyemailpassword.go
+++ b/boilerplate/backend/go-http/config/thirdpartyemailpassword.go
@@ -74,7 +74,7 @@ var SuperTokensConfig = supertokens.TypeInput{
 						},
 					},
 				},
-			}
+			},
 		}),
 		session.Init(nil),
 		dashboard.Init(nil),

--- a/boilerplate/fullstack/astro/package.json
+++ b/boilerplate/fullstack/astro/package.json
@@ -17,6 +17,8 @@
         "@types/react-dom": "^18.2.24",
         "astro": "^4.5.12",
         "cookie": "^0.6.0",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "micromatch": "^4.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/boilerplate/fullstack/astro/src/components/Home.tsx
+++ b/boilerplate/fullstack/astro/src/components/Home.tsx
@@ -3,42 +3,50 @@ import SuperTokens from "supertokens-auth-react";
 import SessionReact from "supertokens-auth-react/recipe/session/index.js";
 import { TryRefreshComponent } from "../components/tryRefreshClientComponent";
 import { SessionAuthForAstro } from "./sessionAuthForAstro";
-
-interface SessionProps {
-    userId: string;
-    sessionHandle: string;
-    accessTokenPayload: object;
-}
+import type { JwtPayload } from "jsonwebtoken";
 
 export default function Home({
-    session,
-    hasInvalidClaims,
+    accessTokenPayload,
     hasToken,
+    error,
 }: {
-    session: SessionProps | undefined;
-    hasInvalidClaims: boolean;
+    accessTokenPayload: JwtPayload | undefined;
     hasToken: boolean;
+    error: Error | undefined;
 }) {
     async function logoutClicked() {
         await SessionReact.signOut();
         SuperTokens.redirectToAuth();
     }
 
-    if (session === undefined) {
+    if (error) {
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
+    }
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
+        /**
+         * This means that the user is not logged in. If you want to display some other UI in this
+         * case, you can do so here.
+         */
         if (!hasToken) {
             location.href = "/auth";
             return;
         }
-        if (hasInvalidClaims) {
-            return <SessionAuthForAstro />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
-    const displaySessionInformationWindow = (sessionData: SessionProps) => {
-        window.alert("Session Information: " + JSON.stringify(sessionData));
+    const fetchUserData = async () => {
+        const userInfoResponse = await fetch("http://localhost:4321/sessioninfo");
+
+        alert(JSON.stringify(await userInfoResponse.json()));
     };
 
     const links: {
@@ -63,6 +71,10 @@ export default function Home({
         },
     ];
 
+    /**
+     * SessionAuthForAstro will handle proper redirection for the user based on the different session states.
+     * It will redirect to the login page if the session does not exist etc.
+     */
     return (
         <SessionAuthForAstro>
             <div className="homeContainer">
@@ -74,9 +86,9 @@ export default function Home({
                     <div className="innerContent">
                         <div>Your userID is: </div>
 
-                        <div className="truncate userId">{session.userId}</div>
+                        <div className="truncate userId">{accessTokenPayload.sub}</div>
 
-                        <button onClick={() => displaySessionInformationWindow(session)} className="sessionButton">
+                        <button onClick={() => fetchUserData()} className="sessionButton">
                             Call API
                         </button>
                     </div>

--- a/boilerplate/fullstack/astro/src/pages/index.astro
+++ b/boilerplate/fullstack/astro/src/pages/index.astro
@@ -4,39 +4,24 @@ import Home from "../components/Home";
 import { getSessionForSSR } from "../superTokensHelpers";
 import { ensureSuperTokensInit } from "../config/backend";
 
-interface SessionProps {
-  userId: string;
-  sessionHandle: string;
-  accessTokenPayload: object;
-}
-
 ensureSuperTokensInit();
 
-const { session, hasInvalidClaims, hasToken } = await getSessionForSSR(
+const { accessTokenPayload, hasToken, error } = await getSessionForSSR(
   Astro.request
 );
 
-let sessionProps: SessionProps | undefined = undefined;
-if (session !== undefined) {
-  sessionProps = {
-    userId: session.getUserId(),
-    sessionHandle: session.getHandle(),
-    accessTokenPayload: session.getAccessTokenPayload(),
-  };
-}
-
 const SSRData = {
-  session: sessionProps,
-  hasInvalidClaims,
+  accessTokenPayload,
   hasToken,
+  error,
 };
 ---
 
 <Base>
   <Home
     client:only="react"
-    session={SSRData.session}
-    hasInvalidClaims={SSRData.hasInvalidClaims}
+    accessTokenPayload={SSRData.accessTokenPayload}
     hasToken={SSRData.hasToken}
+    error={SSRData.error}
   />
 </Base>

--- a/boilerplate/fullstack/astro/src/pages/index.astro
+++ b/boilerplate/fullstack/astro/src/pages/index.astro
@@ -2,9 +2,6 @@
 import Base from "../layouts/Base.astro";
 import Home from "../components/Home";
 import { getSessionForSSR } from "../superTokensHelpers";
-import { ensureSuperTokensInit } from "../config/backend";
-
-ensureSuperTokensInit();
 
 const { accessTokenPayload, hasToken, error } = await getSessionForSSR(
   Astro.request

--- a/boilerplate/fullstack/astro/src/superTokensHelpers.ts
+++ b/boilerplate/fullstack/astro/src/superTokensHelpers.ts
@@ -10,8 +10,43 @@ import { availableTokenTransferMethods } from "supertokens-node/lib/build/recipe
 import { getToken } from "supertokens-node/lib/build/recipe/session/cookieAndHeaders.js";
 import { parseJWTWithoutSignatureVerification } from "supertokens-node/lib/build/recipe/session/jwt.js";
 import { serialize } from "cookie";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import jwksClient from "jwks-rsa";
+import { appInfo } from "./config/appInfo";
 
 type HTTPMethod = "post" | "get" | "delete" | "put" | "options" | "trace";
+
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
+
+function getAccessToken(request: Request): string | undefined {
+    return getCookieFromRequest(request)["sAccessToken"];
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
 
 export function handleAuthAPIRequest(AstroResponse: typeof Response) {
     const stMiddleware = middleware<Request>((req) => {
@@ -147,21 +182,32 @@ async function getSessionDetails(
     }
 }
 
-export async function getSessionForSSR(
-    astroRequest: Request,
-    options?: VerifySessionOptions,
-    userContext?: Record<string, unknown>
-): Promise<{
-    session: SessionContainer | undefined;
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+export async function getSessionForSSR(remixRequest: Request): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
     hasToken: boolean;
-    hasInvalidClaims: boolean;
+    error: Error | undefined;
 }> {
-    const sessionDetails = await getSessionDetails(createPreParsedRequest(astroRequest), options, userContext);
-    return {
-        session: sessionDetails.session,
-        hasInvalidClaims: sessionDetails.hasInvalidClaims,
-        hasToken: sessionDetails.hasToken,
-    };
+    const accessToken = getAccessToken(remixRequest);
+    const hasToken = !!accessToken;
+    try {
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
+    }
 }
 
 export async function withSession(
@@ -194,34 +240,34 @@ export async function withSession(
                 status: baseResponse.statusCode,
                 headers: baseResponse.headers,
             });
+        }
 
-            let didAddCookies = false;
-            let didAddHeaders = false;
+        let didAddCookies = false;
+        let didAddHeaders = false;
 
-            for (const respCookie of baseResponse.cookies) {
-                didAddCookies = true;
-                userResponse.headers.append(
-                    "Set-Cookie",
-                    serialize(respCookie.key, respCookie.value, {
-                        domain: respCookie.domain,
-                        expires: new Date(respCookie.expires),
-                        httpOnly: respCookie.httpOnly,
-                        path: respCookie.path,
-                        sameSite: respCookie.sameSite,
-                        secure: respCookie.secure,
-                    })
-                );
-            }
+        for (const respCookie of baseResponse.cookies) {
+            didAddCookies = true;
+            userResponse.headers.append(
+                "Set-Cookie",
+                serialize(respCookie.key, respCookie.value, {
+                    domain: respCookie.domain,
+                    expires: new Date(respCookie.expires),
+                    httpOnly: respCookie.httpOnly,
+                    path: respCookie.path,
+                    sameSite: respCookie.sameSite,
+                    secure: respCookie.secure,
+                })
+            );
+        }
 
-            baseResponse.headers.forEach((value: string, key: string) => {
-                didAddHeaders = true;
-                userResponse.headers.set(key, value);
-            });
-            if (didAddCookies || didAddHeaders) {
-                if (!userResponse.headers.has("Cache-Control")) {
-                    // This is needed for production deployments with Vercel
-                    userResponse.headers.set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
-                }
+        baseResponse.headers.forEach((value: string, key: string) => {
+            didAddHeaders = true;
+            userResponse.headers.set(key, value);
+        });
+        if (didAddCookies || didAddHeaders) {
+            if (!userResponse.headers.has("Cache-Control")) {
+                // This is needed for production deployments with Vercel
+                userResponse.headers.set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
             }
         }
 

--- a/boilerplate/fullstack/next-app-dir-multitenancy/app/components/home.tsx
+++ b/boilerplate/fullstack/next-app-dir-multitenancy/app/components/home.tsx
@@ -1,4 +1,4 @@
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import styles from "../page.module.css";
 import { redirect } from "next/navigation";
@@ -7,39 +7,82 @@ import { CelebrateIcon, SeparatorLine } from "../../assets/images";
 import { CallAPIButton } from "./callApiButton";
 import { LinksComponent } from "./linksComponent";
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
 import { ensureSuperTokensInit } from "../config/backend";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { appInfo } from "../config/appInfo";
 
 ensureSuperTokensInit();
 
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
+
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
 async function getSSRSessionHelper(): Promise<{
-    session: SessionContainer | undefined;
+    accessTokenPayload: JwtPayload | undefined;
     hasToken: boolean;
-    hasInvalidClaims: boolean;
     error: Error | undefined;
 }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
         return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -48,14 +91,19 @@ export async function HomePage() {
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
+    /**
+     * SessionAuthForNextJS will handle proper redirection for the user based on the different session states.
+     * It will redirect to the login page if the session does not exist etc.
+     */
     return (
         <SessionAuthForNextJS>
             <div className={styles.homeContainer}>
@@ -66,7 +114,7 @@ export async function HomePage() {
                     </div>
                     <div className={styles.innerContent}>
                         <div>Your userID is:</div>
-                        <div className={`${styles.truncate} ${styles.userId}`}>{session.getUserId()}</div>
+                        <div className={`${styles.truncate} ${styles.userId}`}>{accessTokenPayload.sub}</div>
                         <CallAPIButton />
                     </div>
                 </div>

--- a/boilerplate/fullstack/next-app-dir-multitenancy/app/components/home.tsx
+++ b/boilerplate/fullstack/next-app-dir-multitenancy/app/components/home.tsx
@@ -7,13 +7,10 @@ import { CelebrateIcon, SeparatorLine } from "../../assets/images";
 import { CallAPIButton } from "./callApiButton";
 import { LinksComponent } from "./linksComponent";
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
-import { ensureSuperTokensInit } from "../config/backend";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
-
-ensureSuperTokensInit();
 
 const client = jwksClient({
     jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,

--- a/boilerplate/fullstack/next-app-dir-multitenancy/package.json
+++ b/boilerplate/fullstack/next-app-dir-multitenancy/package.json
@@ -9,6 +9,8 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "next": "latest",
         "react": "^18",
         "react-dom": "^18",

--- a/boilerplate/fullstack/next-app-dir/app/components/home.tsx
+++ b/boilerplate/fullstack/next-app-dir/app/components/home.tsx
@@ -1,4 +1,4 @@
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import styles from "../page.module.css";
 import { redirect } from "next/navigation";
@@ -7,39 +7,82 @@ import { CelebrateIcon, SeparatorLine } from "../../assets/images";
 import { CallAPIButton } from "./callApiButton";
 import { LinksComponent } from "./linksComponent";
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
 import { ensureSuperTokensInit } from "../config/backend";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { appInfo } from "../config/appInfo";
 
 ensureSuperTokensInit();
 
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
+
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
 async function getSSRSessionHelper(): Promise<{
-    session: SessionContainer | undefined;
+    accessTokenPayload: JwtPayload | undefined;
     hasToken: boolean;
-    hasInvalidClaims: boolean;
     error: Error | undefined;
 }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
         return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -48,14 +91,19 @@ export async function HomePage() {
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
+    /**
+     * SessionAuthForNextJS will handle proper redirection for the user based on the different session states.
+     * It will redirect to the login page if the session does not exist etc.
+     */
     return (
         <SessionAuthForNextJS>
             <div className={styles.homeContainer}>
@@ -66,7 +114,7 @@ export async function HomePage() {
                     </div>
                     <div className={styles.innerContent}>
                         <div>Your userID is:</div>
-                        <div className={`${styles.truncate} ${styles.userId}`}>{session.getUserId()}</div>
+                        <div className={`${styles.truncate} ${styles.userId}`}>{accessTokenPayload.sub}</div>
                         <CallAPIButton />
                     </div>
                 </div>

--- a/boilerplate/fullstack/next-app-dir/app/components/home.tsx
+++ b/boilerplate/fullstack/next-app-dir/app/components/home.tsx
@@ -7,13 +7,10 @@ import { CelebrateIcon, SeparatorLine } from "../../assets/images";
 import { CallAPIButton } from "./callApiButton";
 import { LinksComponent } from "./linksComponent";
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
-import { ensureSuperTokensInit } from "../config/backend";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
-
-ensureSuperTokensInit();
 
 const client = jwksClient({
     jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,

--- a/boilerplate/fullstack/next-app-dir/package.json
+++ b/boilerplate/fullstack/next-app-dir/package.json
@@ -9,6 +9,8 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "next": "latest",
         "react": "^18",
         "react-dom": "^18",

--- a/boilerplate/fullstack/remix/package.json
+++ b/boilerplate/fullstack/remix/package.json
@@ -18,6 +18,8 @@
         "cors": "^2.8.5",
         "isbot": "^4.1.0",
         "jsdom-global": "^3.0.2",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "puppeteer": "^22.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary of change

This PR updates the boilerplate of Astro, Remix and NextJS (app dir) to remove the `getSession` usage in the SSR. 

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required
