### PR TITLE
Set port details on `npm run start`

### DIFF
--- a/boilerplate/backend/node-express/index.ts
+++ b/boilerplate/backend/node-express/index.ts
@@ -43,4 +43,6 @@ app.get("/tenants", async (req, res) => {
 // returns 401 to the client.
 app.use(errorHandler());
 
-app.listen(3001, () => console.log(`API Server listening on port 3001`));
+const port = process.env.PORT || 3001;
+
+app.listen(port, () => console.log(`API Server listening on port ${port}`));

--- a/boilerplate/backend/node-express/package.json
+++ b/boilerplate/backend/node-express/package.json
@@ -22,7 +22,8 @@
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.3",
         "@types/node": "^16.11.38",
-        "nodemon": "^2.0.16"
+        "nodemon": "^2.0.16",
+        "cross-env": "^7.0.3"
     },
     "keywords": [],
     "author": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "create-supertokens-app",
-            "version": "0.0.50",
+            "version": "0.0.51",
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",


### PR DESCRIPTION
## Summary of change

We can define the ports that the `npm run start` command will use, default is 3031.
We can specify a custom port when running your application:

```sh
PORT=8080 npm run start
```


## Related issues

-   #108 

## Checklist for important updates

-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook