### PR TITLE
fix: Python code formatting, import order

### DIFF
--- a/boilerplate/backend/shared/python/py.ts
+++ b/boilerplate/backend/shared/python/py.ts
@@ -4,6 +4,7 @@ import { config } from "../../../shared/config/base.js";
 import { getAppInfo } from "../../../shared/config/appInfo.js";
 import { thirdPartyLoginProviders } from "../../../backend/shared/config/oAuthProviders.js";
 import { UserFlags } from "../../../../lib/ts/types.js";
+import dedent from "dedent";
 
 interface PythonTemplate {
     configType: ConfigType;
@@ -28,44 +29,41 @@ export const pyRecipeImports = {
 
 const app_info_object = getAppInfo();
 
-export const pyBaseTemplate = `
-from supertokens_python import init, InputAppInfo, SupertokensConfig
-import os
+export const pyBaseTemplate = dedent`
+    def get_api_domain() -> str:
+        api_port = str(${app_info_object.defaultApiPort})
+        api_url = f"http://localhost:{api_port}"
+        return api_url
 
-def get_api_domain() -> str:
-    api_port = str(${app_info_object.defaultApiPort})
-    api_url = f"http://localhost:{api_port}"
-    return api_url
+    def get_website_domain() -> str:
+        website_port = str(${app_info_object.defaultWebsitePort})
+        website_url = f"http://localhost:{website_port}"
+        return website_url
 
-def get_website_domain() -> str:
-    website_port = str(${app_info_object.defaultWebsitePort})
-    website_url = f"http://localhost:{website_port}"
-    return website_url
+    supertokens_config = SupertokensConfig(
+        connection_uri="${config.connectionURI}"
+    )
 
-supertokens_config = SupertokensConfig(
-    connection_uri="${config.connectionURI}"
-)
+    app_info = InputAppInfo(
+        app_name="${getAppInfo().appName}",
+        api_domain=get_api_domain(),
+        website_domain=get_website_domain(),
+        api_base_path="/auth",
+        website_base_path="/auth"
+    )
 
-app_info = InputAppInfo(
-    app_name="${getAppInfo().appName}",
-    api_domain=get_api_domain(),
-    website_domain=get_website_domain(),
-    api_base_path="/auth",
-    website_base_path="/auth"
-)
+    recipe_list = [
+        %RECIPE_LIST%
+    ]
 
-recipe_list = [
-    %RECIPE_LIST%
-]
-
-init(
-    supertokens_config=supertokens_config,
-    app_info=app_info,
-    framework="%FRAMEWORK%",
-    recipe_list=recipe_list,
-    mode="%MODE%",
-    telemetry=False
-)
+    init(
+        supertokens_config=supertokens_config,
+        app_info=app_info,
+        framework="%FRAMEWORK%",
+        recipe_list=recipe_list,
+        mode="%MODE%",
+        telemetry=False
+    )
 `;
 
 export const pyRecipeInits = {
@@ -169,6 +167,10 @@ export const pyRecipeInits = {
 } as const;
 
 export const generatePythonTemplate = ({ configType, userArguments, framework }: PythonTemplate): string => {
+    console.log(configType);
+    console.log(userArguments);
+    console.log(framework);
+
     const recipesSet = new Set<string>(["session", "dashboard", "userRoles"]);
 
     if (userArguments?.firstfactors || userArguments?.secondfactors) {
@@ -202,10 +204,10 @@ export const generatePythonTemplate = ({ configType, userArguments, framework }:
         recipes.push("accountLinking");
     }
 
-    let imports = recipes
+    const imports: string[] = recipes
         .map((recipe) => pyRecipeImports[recipe as keyof typeof pyRecipeImports])
-        .filter(Boolean)
-        .join("\n");
+        .filter(Boolean);
+    const miscFunctions: string[] = [];
 
     if (recipes.includes("passwordless")) {
         const hasLinkEmail =
@@ -218,20 +220,21 @@ export const generatePythonTemplate = ({ configType, userArguments, framework }:
             userArguments?.firstfactors?.includes("otp-phone") || userArguments?.secondfactors?.includes("otp-phone");
 
         if ((hasLinkEmail || hasOtpEmail) && (hasLinkPhone || hasOtpPhone)) {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactEmailOrPhoneConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactEmailOrPhoneConfig");
         } else if (hasLinkPhone || hasOtpPhone) {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactPhoneConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactPhoneConfig");
         } else {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactEmailConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactEmailConfig");
         }
     }
 
     let typingImports = new Set<string>();
     if (recipes.includes("accountLinking")) {
-        imports += `
-from supertokens_python.recipe.accountlinking.types import AccountInfoWithRecipeIdAndUserId, ShouldAutomaticallyLink, ShouldNotAutomaticallyLink
-from supertokens_python.recipe.session.interfaces import SessionContainer
-from supertokens_python.types import User`;
+        imports.push(
+            "from supertokens_python.recipe.accountlinking.types import AccountInfoWithRecipeIdAndUserId, ShouldAutomaticallyLink, ShouldNotAutomaticallyLink",
+            "from supertokens_python.recipe.session.interfaces import SessionContainer",
+            "from supertokens_python.types import User"
+        );
         typingImports.add("Optional");
         typingImports.add("Dict");
         typingImports.add("Any");
@@ -239,9 +242,10 @@ from supertokens_python.types import User`;
     }
 
     if (hasMFA && userArguments?.secondfactors && userArguments.secondfactors.length > 0) {
-        imports += `
-from supertokens_python.recipe.multifactorauth.interfaces import RecipeInterface as MFARecipeInterface
-from supertokens_python.recipe.multifactorauth.types import MFARequirementList, FactorIds`;
+        imports.push(
+            "from supertokens_python.recipe.multifactorauth.interfaces import RecipeInterface as MFARecipeInterface",
+            "from supertokens_python.recipe.multifactorauth.types import MFARequirementList, FactorIds"
+        );
         typingImports.add("Callable");
         typingImports.add("Awaitable");
         typingImports.add("List");
@@ -250,27 +254,51 @@ from supertokens_python.recipe.multifactorauth.types import MFARequirementList, 
     }
 
     if (typingImports.size > 0) {
-        imports += `\nfrom typing import ${[...typingImports].join(", ")}`;
+        imports.push(`from typing import ${[...typingImports].join(", ")}`);
     }
 
     if (hasMFA && userArguments?.secondfactors && userArguments.secondfactors.length > 0) {
-        imports += `
+        miscFunctions.push(dedent`
+            def override_multifactor_functions(original_implementation: MFARecipeInterface):
+                async def get_mfa_requirements_for_auth(
+                    tenant_id: str,
+                    access_token_payload: dict,
+                    completed_factors: dict,
+                    user,
+                    factors_set_up_for_user,
+                    required_secondary_factors_for_user,
+                    required_secondary_factors_for_tenant,
+                    user_context: dict,
+                ) -> MFARequirementList:
+                    return [
+                        {
+                            "oneOf": [
+                                ${userArguments.secondfactors
+                                    .map((factor: string) => {
+                                        const factorMapping: Record<string, string> = {
+                                            totp: "FactorIds.TOTP",
+                                            "otp-email": "FactorIds.OTP_EMAIL",
+                                            "otp-phone": "FactorIds.OTP_PHONE",
+                                            "link-email": "FactorIds.LINK_EMAIL",
+                                            "link-phone": "FactorIds.LINK_PHONE",
+                                            otp_email: "FactorIds.OTP_EMAIL",
+                                            otp_phone: "FactorIds.OTP_PHONE",
+                                            link_email: "FactorIds.LINK_EMAIL",
+                                            link_phone: "FactorIds.LINK_PHONE",
+                                        };
+                                        return factorMapping[factor] || `"${factor}"`;
+                                    })
+                                    .join(", ")}
+                            ],
+                        }
+                    ]
 
-def override_multifactor_functions(original_implementation: MFARecipeInterface):
-    async def get_mfa_requirements_for_auth(
-        tenant_id: str,
-        access_token_payload: dict,
-        completed_factors: dict,
-        user,
-        factors_set_up_for_user,
-        required_secondary_factors_for_user,
-        required_secondary_factors_for_tenant,
-        user_context: dict,
-    ) -> MFARequirementList:
-        return [
-            {
-                "oneOf": [
-                    ${userArguments.secondfactors
+                async def get_required_secondary_factors_for_user(
+                    tenant_id: str,
+                    user_id: str,
+                    user_context: dict,
+                ) -> list:
+                    return [${userArguments.secondfactors
                         .map((factor: string) => {
                             const factorMapping: Record<string, string> = {
                                 totp: "FactorIds.TOTP",
@@ -285,36 +313,12 @@ def override_multifactor_functions(original_implementation: MFARecipeInterface):
                             };
                             return factorMapping[factor] || `"${factor}"`;
                         })
-                        .join(", ")}
-                ],
-            }
-        ]
+                        .join(", ")}]
 
-    async def get_required_secondary_factors_for_user(
-        tenant_id: str,
-        user_id: str,
-        user_context: dict,
-    ) -> list:
-        return [${userArguments.secondfactors
-            .map((factor: string) => {
-                const factorMapping: Record<string, string> = {
-                    totp: "FactorIds.TOTP",
-                    "otp-email": "FactorIds.OTP_EMAIL",
-                    "otp-phone": "FactorIds.OTP_PHONE",
-                    "link-email": "FactorIds.LINK_EMAIL",
-                    "link-phone": "FactorIds.LINK_PHONE",
-                    otp_email: "FactorIds.OTP_EMAIL",
-                    otp_phone: "FactorIds.OTP_PHONE",
-                    link_email: "FactorIds.LINK_EMAIL",
-                    link_phone: "FactorIds.LINK_PHONE",
-                };
-                return factorMapping[factor] || `"${factor}"`;
-            })
-            .join(", ")}]
-
-    original_implementation.get_mfa_requirements_for_auth = get_mfa_requirements_for_auth
-    original_implementation.get_required_secondary_factors_for_user = get_required_secondary_factors_for_user
-    return original_implementation`;
+                original_implementation.get_mfa_requirements_for_auth = get_mfa_requirements_for_auth
+                original_implementation.get_required_secondary_factors_for_user = get_required_secondary_factors_for_user
+                return original_implementation
+        `);
     }
 
     const recipeList = recipes
@@ -365,19 +369,23 @@ def override_multifactor_functions(original_implementation: MFARecipeInterface):
     finalTemplate = finalTemplate.replace("%FRAMEWORK%", sdkFramework);
     finalTemplate = finalTemplate.replace("%MODE%", sdkMode);
 
-    const async_linking_func_def = recipes.includes("accountLinking")
-        ? `
+    // Add common imports
+    imports.unshift("from supertokens_python import init, InputAppInfo, SupertokensConfig");
 
-async def async_should_do_linking(
-    new_account_info: AccountInfoWithRecipeIdAndUserId,
-    user: Optional[User],
-    session: Optional[SessionContainer],
-    tenant_id: str,
-    user_context: Dict[str, Any],
-) -> Union[ShouldNotAutomaticallyLink, ShouldAutomaticallyLink]:
-    return ShouldAutomaticallyLink(should_require_verification=False)
-`
-        : "";
+    if (recipes.includes("accountlinking")) {
+        miscFunctions.push(dedent`
+            async def async_should_do_linking(
+                new_account_info: AccountInfoWithRecipeIdAndUserId,
+                user: Optional[User],
+                session: Optional[SessionContainer],
+                tenant_id: str,
+                user_context: Dict[str, Any],
+            ) -> Union[ShouldNotAutomaticallyLink, ShouldAutomaticallyLink]:
+                return ShouldAutomaticallyLink(should_require_verification=False)
+        `);
+    }
 
-    return imports + "\n" + async_linking_func_def + "\n\n" + finalTemplate;
+    console.log(miscFunctions);
+
+    return imports.join("\n") + "\n\n" + miscFunctions.join("\n\n") + "\n\n" + finalTemplate;
 };

--- a/boilerplate/backend/shared/python/py.ts
+++ b/boilerplate/backend/shared/python/py.ts
@@ -82,7 +82,10 @@ export const pyRecipeInits = {
                                 client_secret="${provider.clientSecret}"${
                             provider.additionalConfig
                                 ? `,
-                                additional_config=${JSON.stringify(provider.additionalConfig, null, 16)}`
+                                additional_config=${JSON.stringify(provider.additionalConfig, null, "####").replace(
+                                    new RegExp("####", "g"),
+                                    "".padStart(36)
+                                )}`
                                 : ""
                         }
                             )
@@ -167,10 +170,6 @@ export const pyRecipeInits = {
 } as const;
 
 export const generatePythonTemplate = ({ configType, userArguments, framework }: PythonTemplate): string => {
-    console.log(configType);
-    console.log(userArguments);
-    console.log(framework);
-
     const recipesSet = new Set<string>(["session", "dashboard", "userRoles"]);
 
     if (userArguments?.firstfactors || userArguments?.secondfactors) {
@@ -372,7 +371,7 @@ export const generatePythonTemplate = ({ configType, userArguments, framework }:
     // Add common imports
     imports.unshift("from supertokens_python import init, InputAppInfo, SupertokensConfig");
 
-    if (recipes.includes("accountlinking")) {
+    if (recipes.includes("accountLinking")) {
         miscFunctions.push(dedent`
             async def async_should_do_linking(
                 new_account_info: AccountInfoWithRecipeIdAndUserId,
@@ -384,8 +383,6 @@ export const generatePythonTemplate = ({ configType, userArguments, framework }:
                 return ShouldAutomaticallyLink(should_require_verification=False)
         `);
     }
-
-    console.log(miscFunctions);
 
     return imports.join("\n") + "\n\n" + miscFunctions.join("\n\n") + "\n\n" + finalTemplate;
 };

--- a/lib/build/boilerplate/backend/shared/python/py.js
+++ b/lib/build/boilerplate/backend/shared/python/py.js
@@ -70,7 +70,10 @@ export const pyRecipeInits = {
                                 client_secret="${provider.clientSecret}"${
                             provider.additionalConfig
                                 ? `,
-                                additional_config=${JSON.stringify(provider.additionalConfig, null, 16)}`
+                                additional_config=${JSON.stringify(provider.additionalConfig, null, "####").replace(
+                                    new RegExp("####", "g"),
+                                    "".padStart(36)
+                                )}`
                                 : ""
                         }
                             )
@@ -148,9 +151,6 @@ export const pyRecipeInits = {
     )`,
 };
 export const generatePythonTemplate = ({ configType, userArguments, framework }) => {
-    console.log(configType);
-    console.log(userArguments);
-    console.log(framework);
     const recipesSet = new Set(["session", "dashboard", "userRoles"]);
     if (userArguments?.firstfactors || userArguments?.secondfactors) {
         const factors = [...(userArguments.firstfactors || []), ...(userArguments.secondfactors || [])];
@@ -330,7 +330,7 @@ export const generatePythonTemplate = ({ configType, userArguments, framework })
     finalTemplate = finalTemplate.replace("%MODE%", sdkMode);
     // Add common imports
     imports.unshift("from supertokens_python import init, InputAppInfo, SupertokensConfig");
-    if (recipes.includes("accountlinking")) {
+    if (recipes.includes("accountLinking")) {
         miscFunctions.push(dedent`
             async def async_should_do_linking(
                 new_account_info: AccountInfoWithRecipeIdAndUserId,
@@ -342,6 +342,5 @@ export const generatePythonTemplate = ({ configType, userArguments, framework })
                 return ShouldAutomaticallyLink(should_require_verification=False)
         `);
     }
-    console.log(miscFunctions);
-    return imports.join("\n") + "\n" + miscFunctions.join("\n\n") + "\n\n" + finalTemplate;
+    return imports.join("\n") + "\n\n" + miscFunctions.join("\n\n") + "\n\n" + finalTemplate;
 };

--- a/lib/build/boilerplate/backend/shared/python/py.js
+++ b/lib/build/boilerplate/backend/shared/python/py.js
@@ -2,6 +2,7 @@ import { configToRecipes } from "../../../../lib/ts/templateBuilder/constants.js
 import { config } from "../../../shared/config/base.js";
 import { getAppInfo } from "../../../shared/config/appInfo.js";
 import { thirdPartyLoginProviders } from "../../../backend/shared/config/oAuthProviders.js";
+import dedent from "dedent";
 export const pyRecipeImports = {
     emailPassword: "from supertokens_python.recipe import emailpassword",
     thirdParty:
@@ -17,44 +18,41 @@ export const pyRecipeImports = {
     multitenancy: "from supertokens_python.recipe import multitenancy",
 };
 const app_info_object = getAppInfo();
-export const pyBaseTemplate = `
-from supertokens_python import init, InputAppInfo, SupertokensConfig
-import os
+export const pyBaseTemplate = dedent`
+    def get_api_domain() -> str:
+        api_port = str(${app_info_object.defaultApiPort})
+        api_url = f"http://localhost:{api_port}"
+        return api_url
 
-def get_api_domain() -> str:
-    api_port = str(${app_info_object.defaultApiPort})
-    api_url = f"http://localhost:{api_port}"
-    return api_url
+    def get_website_domain() -> str:
+        website_port = str(${app_info_object.defaultWebsitePort})
+        website_url = f"http://localhost:{website_port}"
+        return website_url
 
-def get_website_domain() -> str:
-    website_port = str(${app_info_object.defaultWebsitePort})
-    website_url = f"http://localhost:{website_port}"
-    return website_url
+    supertokens_config = SupertokensConfig(
+        connection_uri="${config.connectionURI}"
+    )
 
-supertokens_config = SupertokensConfig(
-    connection_uri="${config.connectionURI}"
-)
+    app_info = InputAppInfo(
+        app_name="${getAppInfo().appName}",
+        api_domain=get_api_domain(),
+        website_domain=get_website_domain(),
+        api_base_path="/auth",
+        website_base_path="/auth"
+    )
 
-app_info = InputAppInfo(
-    app_name="${getAppInfo().appName}",
-    api_domain=get_api_domain(),
-    website_domain=get_website_domain(),
-    api_base_path="/auth",
-    website_base_path="/auth"
-)
+    recipe_list = [
+        %RECIPE_LIST%
+    ]
 
-recipe_list = [
-    %RECIPE_LIST%
-]
-
-init(
-    supertokens_config=supertokens_config,
-    app_info=app_info,
-    framework="%FRAMEWORK%",
-    recipe_list=recipe_list,
-    mode="%MODE%",
-    telemetry=False
-)
+    init(
+        supertokens_config=supertokens_config,
+        app_info=app_info,
+        framework="%FRAMEWORK%",
+        recipe_list=recipe_list,
+        mode="%MODE%",
+        telemetry=False
+    )
 `;
 export const pyRecipeInits = {
     emailPassword: () => `emailpassword.init()`,
@@ -150,6 +148,9 @@ export const pyRecipeInits = {
     )`,
 };
 export const generatePythonTemplate = ({ configType, userArguments, framework }) => {
+    console.log(configType);
+    console.log(userArguments);
+    console.log(framework);
     const recipesSet = new Set(["session", "dashboard", "userRoles"]);
     if (userArguments?.firstfactors || userArguments?.secondfactors) {
         const factors = [...(userArguments.firstfactors || []), ...(userArguments.secondfactors || [])];
@@ -175,10 +176,8 @@ export const generatePythonTemplate = ({ configType, userArguments, framework })
     if (hasMFA && !recipes.includes("accountLinking")) {
         recipes.push("accountLinking");
     }
-    let imports = recipes
-        .map((recipe) => pyRecipeImports[recipe])
-        .filter(Boolean)
-        .join("\n");
+    const imports = recipes.map((recipe) => pyRecipeImports[recipe]).filter(Boolean);
+    const miscFunctions = [];
     if (recipes.includes("passwordless")) {
         const hasLinkEmail =
             userArguments?.firstfactors?.includes("link-email") || userArguments?.secondfactors?.includes("link-email");
@@ -189,28 +188,30 @@ export const generatePythonTemplate = ({ configType, userArguments, framework })
         const hasOtpPhone =
             userArguments?.firstfactors?.includes("otp-phone") || userArguments?.secondfactors?.includes("otp-phone");
         if ((hasLinkEmail || hasOtpEmail) && (hasLinkPhone || hasOtpPhone)) {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactEmailOrPhoneConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactEmailOrPhoneConfig");
         } else if (hasLinkPhone || hasOtpPhone) {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactPhoneConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactPhoneConfig");
         } else {
-            imports += "\nfrom supertokens_python.recipe.passwordless import ContactEmailConfig";
+            imports.push("from supertokens_python.recipe.passwordless import ContactEmailConfig");
         }
     }
     let typingImports = new Set();
     if (recipes.includes("accountLinking")) {
-        imports += `
-from supertokens_python.recipe.accountlinking.types import AccountInfoWithRecipeIdAndUserId, ShouldAutomaticallyLink, ShouldNotAutomaticallyLink
-from supertokens_python.recipe.session.interfaces import SessionContainer
-from supertokens_python.types import User`;
+        imports.push(
+            "from supertokens_python.recipe.accountlinking.types import AccountInfoWithRecipeIdAndUserId, ShouldAutomaticallyLink, ShouldNotAutomaticallyLink",
+            "from supertokens_python.recipe.session.interfaces import SessionContainer",
+            "from supertokens_python.types import User"
+        );
         typingImports.add("Optional");
         typingImports.add("Dict");
         typingImports.add("Any");
         typingImports.add("Union");
     }
     if (hasMFA && userArguments?.secondfactors && userArguments.secondfactors.length > 0) {
-        imports += `
-from supertokens_python.recipe.multifactorauth.interfaces import RecipeInterface as MFARecipeInterface
-from supertokens_python.recipe.multifactorauth.types import MFARequirementList, FactorIds`;
+        imports.push(
+            "from supertokens_python.recipe.multifactorauth.interfaces import RecipeInterface as MFARecipeInterface",
+            "from supertokens_python.recipe.multifactorauth.types import MFARequirementList, FactorIds"
+        );
         typingImports.add("Callable");
         typingImports.add("Awaitable");
         typingImports.add("List");
@@ -218,26 +219,50 @@ from supertokens_python.recipe.multifactorauth.types import MFARequirementList, 
         typingImports.add("Any");
     }
     if (typingImports.size > 0) {
-        imports += `\nfrom typing import ${[...typingImports].join(", ")}`;
+        imports.push(`from typing import ${[...typingImports].join(", ")}`);
     }
     if (hasMFA && userArguments?.secondfactors && userArguments.secondfactors.length > 0) {
-        imports += `
+        miscFunctions.push(dedent`
+            def override_multifactor_functions(original_implementation: MFARecipeInterface):
+                async def get_mfa_requirements_for_auth(
+                    tenant_id: str,
+                    access_token_payload: dict,
+                    completed_factors: dict,
+                    user,
+                    factors_set_up_for_user,
+                    required_secondary_factors_for_user,
+                    required_secondary_factors_for_tenant,
+                    user_context: dict,
+                ) -> MFARequirementList:
+                    return [
+                        {
+                            "oneOf": [
+                                ${userArguments.secondfactors
+                                    .map((factor) => {
+                                        const factorMapping = {
+                                            totp: "FactorIds.TOTP",
+                                            "otp-email": "FactorIds.OTP_EMAIL",
+                                            "otp-phone": "FactorIds.OTP_PHONE",
+                                            "link-email": "FactorIds.LINK_EMAIL",
+                                            "link-phone": "FactorIds.LINK_PHONE",
+                                            otp_email: "FactorIds.OTP_EMAIL",
+                                            otp_phone: "FactorIds.OTP_PHONE",
+                                            link_email: "FactorIds.LINK_EMAIL",
+                                            link_phone: "FactorIds.LINK_PHONE",
+                                        };
+                                        return factorMapping[factor] || `"${factor}"`;
+                                    })
+                                    .join(", ")}
+                            ],
+                        }
+                    ]
 
-def override_multifactor_functions(original_implementation: MFARecipeInterface):
-    async def get_mfa_requirements_for_auth(
-        tenant_id: str,
-        access_token_payload: dict,
-        completed_factors: dict,
-        user,
-        factors_set_up_for_user,
-        required_secondary_factors_for_user,
-        required_secondary_factors_for_tenant,
-        user_context: dict,
-    ) -> MFARequirementList:
-        return [
-            {
-                "oneOf": [
-                    ${userArguments.secondfactors
+                async def get_required_secondary_factors_for_user(
+                    tenant_id: str,
+                    user_id: str,
+                    user_context: dict,
+                ) -> list:
+                    return [${userArguments.secondfactors
                         .map((factor) => {
                             const factorMapping = {
                                 totp: "FactorIds.TOTP",
@@ -252,36 +277,12 @@ def override_multifactor_functions(original_implementation: MFARecipeInterface):
                             };
                             return factorMapping[factor] || `"${factor}"`;
                         })
-                        .join(", ")}
-                ],
-            }
-        ]
+                        .join(", ")}]
 
-    async def get_required_secondary_factors_for_user(
-        tenant_id: str,
-        user_id: str,
-        user_context: dict,
-    ) -> list:
-        return [${userArguments.secondfactors
-            .map((factor) => {
-                const factorMapping = {
-                    totp: "FactorIds.TOTP",
-                    "otp-email": "FactorIds.OTP_EMAIL",
-                    "otp-phone": "FactorIds.OTP_PHONE",
-                    "link-email": "FactorIds.LINK_EMAIL",
-                    "link-phone": "FactorIds.LINK_PHONE",
-                    otp_email: "FactorIds.OTP_EMAIL",
-                    otp_phone: "FactorIds.OTP_PHONE",
-                    link_email: "FactorIds.LINK_EMAIL",
-                    link_phone: "FactorIds.LINK_PHONE",
-                };
-                return factorMapping[factor] || `"${factor}"`;
-            })
-            .join(", ")}]
-
-    original_implementation.get_mfa_requirements_for_auth = get_mfa_requirements_for_auth
-    original_implementation.get_required_secondary_factors_for_user = get_required_secondary_factors_for_user
-    return original_implementation`;
+                original_implementation.get_mfa_requirements_for_auth = get_mfa_requirements_for_auth
+                original_implementation.get_required_secondary_factors_for_user = get_required_secondary_factors_for_user
+                return original_implementation
+        `);
     }
     const recipeList = recipes
         .map((recipe) => {
@@ -327,18 +328,20 @@ def override_multifactor_functions(original_implementation: MFARecipeInterface):
     let finalTemplate = pyBaseTemplate.replace("%RECIPE_LIST%", recipeList);
     finalTemplate = finalTemplate.replace("%FRAMEWORK%", sdkFramework);
     finalTemplate = finalTemplate.replace("%MODE%", sdkMode);
-    const async_linking_func_def = recipes.includes("accountLinking")
-        ? `
-
-async def async_should_do_linking(
-    new_account_info: AccountInfoWithRecipeIdAndUserId,
-    user: Optional[User],
-    session: Optional[SessionContainer],
-    tenant_id: str,
-    user_context: Dict[str, Any],
-) -> Union[ShouldNotAutomaticallyLink, ShouldAutomaticallyLink]:
-    return ShouldAutomaticallyLink(should_require_verification=False)
-`
-        : "";
-    return imports + "\n" + async_linking_func_def + "\n\n" + finalTemplate;
+    // Add common imports
+    imports.unshift("from supertokens_python import init, InputAppInfo, SupertokensConfig");
+    if (recipes.includes("accountlinking")) {
+        miscFunctions.push(dedent`
+            async def async_should_do_linking(
+                new_account_info: AccountInfoWithRecipeIdAndUserId,
+                user: Optional[User],
+                session: Optional[SessionContainer],
+                tenant_id: str,
+                user_context: Dict[str, Any],
+            ) -> Union[ShouldNotAutomaticallyLink, ShouldAutomaticallyLink]:
+                return ShouldAutomaticallyLink(should_require_verification=False)
+        `);
+    }
+    console.log(miscFunctions);
+    return imports.join("\n") + "\n" + miscFunctions.join("\n\n") + "\n\n" + finalTemplate;
 };

--- a/lib/build/lib/ts/index.js
+++ b/lib/build/lib/ts/index.js
@@ -34,6 +34,7 @@ async function checkVersion() {
             Logger.warn(
                 `A new version of the SuperTokens CLI is available: ${remoteVersion}. Your local version is ${localVersion}.`
             );
+            Logger.warn(`You can use the latest CLI version by running "npx create-supertokens-app@latest".`);
             break;
         }
         case 1: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "chalk": "^5.0.1",
+                "dedent": "^1.6.0",
                 "figlet": "^1.5.2",
                 "inquirer": "^9.1.0",
                 "node-emoji": "^1.11.0",
@@ -1709,6 +1710,20 @@
             },
             "peerDependenciesMeta": {
                 "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/dedent": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
                     "optional": true
                 }
             }
@@ -8266,6 +8281,12 @@
             "requires": {
                 "ms": "^2.1.3"
             }
+        },
+        "dedent": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+            "requires": {}
         },
         "deep-eql": {
             "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "chalk": "^5.0.1",
+        "dedent": "^1.6.0",
         "figlet": "^1.5.2",
         "inquirer": "^9.1.0",
         "node-emoji": "^1.11.0",


### PR DESCRIPTION
## Summary of change

- Fixes import order in Python apps
- Fixes indentation for configs

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
