### PR TITLE
Remove window as any cast in template

### DIFF
--- a/.cursor/rules/web-js.mdc
+++ b/.cursor/rules/web-js.mdc
@@ -1,21 +1,21 @@
 ---
-description: 
-globs: 
+description:
+globs:
 alwaysApply: false
 ---
 ## WebJS
 
 | factor          | webjs imports                                            | webjs inits                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `emailpassword` | import SuperTokens from "supertokens-web-js";            | (window as any).supertokensUIEmailPassword.init(),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `thirdparty`    | import SuperTokens from "supertokens-web-js";            | (window as any).supertokensUIThirdParty.init({<br>                signInAndUpFeature: {<br>                    providers: [<br>                        (window as any).supertokensUIThirdParty.Github.init(),<br>                        (window as any).supertokensUIThirdParty.Google.init(),<br>                        (window as any).supertokensUIThirdParty.Apple.init(),<br>                        (window as any).supertokensUIThirdParty.Twitter.init(),<br>                    ],<br>                },<br>            }), |
-| `link_email`    | import Session from "supertokens-web-js/recipe/session"; | (window as any).supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `link_phone`    | import Session from "supertokens-web-js/recipe/session"; | (window as any).supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `otp_phone`     | import Session from "supertokens-web-js/recipe/session"; | (window as any).supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `otp_email`     | import Session from "supertokens-web-js/recipe/session"; | (window as any).supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `totp`          | import SuperTokens from "supertokens-web-js";            | (window as any).supertokensUITOTP.init(),<br>            (window as any).supertokensUISession.init(),                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `emailpassword` | import SuperTokens from "supertokens-web-js";            | window.supertokensUIEmailPassword.init(),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `thirdparty`    | import SuperTokens from "supertokens-web-js";            | window.supertokensUIThirdParty.init({<br>                signInAndUpFeature: {<br>                    providers: [<br>                        window.supertokensUIThirdParty.Github.init(),<br>                        window.supertokensUIThirdParty.Google.init(),<br>                        window.supertokensUIThirdParty.Apple.init(),<br>                        window.supertokensUIThirdParty.Twitter.init(),<br>                    ],<br>                },<br>            }), |
+| `link_email`    | import Session from "supertokens-web-js/recipe/session"; | window.supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `link_phone`    | import Session from "supertokens-web-js/recipe/session"; | window.supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `otp_phone`     | import Session from "supertokens-web-js/recipe/session"; | window.supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `otp_email`     | import Session from "supertokens-web-js/recipe/session"; | window.supertokensUIPasswordless.init({<br>                contactMethod: "EMAIL_OR_PHONE",<br>            }),                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `totp`          | import SuperTokens from "supertokens-web-js";            | window.supertokensUITOTP.init(),<br>            window.supertokensUISession.init(),                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
-**Notes**: 
+**Notes**:
 - Session, Dashboard, UserRoles also imported for all factors, in addition to their own config.
 - if both link_email and link_phone are present as factors, the contactMethod in init becomes "EMAIL_OR_PASSWORD".
 - if both otp_email and otp_phone are present as factors, the flowType in init becomes "USER_INPUT_CODE_AND_MAGIC_LINK".
@@ -31,28 +31,28 @@ import SuperTokens from "supertokens-web-js";
 import Session from "supertokens-web-js/recipe/session";
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: "http://localhost:3000",
             apiDomain: "http://localhost:3001",
             appName: "SuperTokens Demo App",
         },
         recipeList: [
-            (window as any).supertokensUIEmailPassword.init(),
-            (window as any).supertokensUIThirdParty.init({
+            window.supertokensUIEmailPassword.init(),
+            window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
-                        (window as any).supertokensUIThirdParty.Github.init(),
-                        (window as any).supertokensUIThirdParty.Google.init(),
-                        (window as any).supertokensUIThirdParty.Apple.init(),
-                        (window as any).supertokensUIThirdParty.Twitter.init(),
+                        window.supertokensUIThirdParty.Github.init(),
+                        window.supertokensUIThirdParty.Google.init(),
+                        window.supertokensUIThirdParty.Apple.init(),
+                        window.supertokensUIThirdParty.Twitter.init(),
                     ],
                 },
             }),
-            (window as any).supertokensUIPasswordless.init({
+            window.supertokensUIPasswordless.init({
                 contactMethod: "EMAIL_OR_PHONE",
             }),
-            (window as any).supertokensUISession.init(),
+            window.supertokensUISession.init(),
         ],
     });
 }
@@ -77,35 +77,35 @@ import EmailVerification from "supertokens-web-js/recipe/emailverification";
 import MultiFactorAuth from "supertokens-web-js/recipe/multifactorauth";
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: "http://localhost:3000",
             apiDomain: "http://localhost:3001",
             appName: "SuperTokens Demo App",
         },
         recipeList: [
-            (window as any).supertokensUIEmailPassword.init(),
-            (window as any).supertokensUIThirdParty.init({
+            window.supertokensUIEmailPassword.init(),
+            window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
-                        (window as any).supertokensUIThirdParty.Github.init(),
-                        (window as any).supertokensUIThirdParty.Google.init(),
-                        (window as any).supertokensUIThirdParty.Apple.init(),
-                        (window as any).supertokensUIThirdParty.Twitter.init(),
+                        window.supertokensUIThirdParty.Github.init(),
+                        window.supertokensUIThirdParty.Google.init(),
+                        window.supertokensUIThirdParty.Apple.init(),
+                        window.supertokensUIThirdParty.Twitter.init(),
                     ],
                 },
             }),
-            (window as any).supertokensUIPasswordless.init({
+            window.supertokensUIPasswordless.init({
                 contactMethod: "EMAIL_OR_PHONE",
             }),
-            (window as any).supertokensUIEmailVerification.init({
+            window.supertokensUIEmailVerification.init({
                 mode: "REQUIRED",
             }),
-            (window as any).supertokensUIMultiFactorAuth.init({
+            window.supertokensUIMultiFactorAuth.init({
                 firstFactors: ["thirdparty", "emailpassword"],
             }),
-            (window as any).supertokensUITOTP.init(),
-            (window as any).supertokensUISession.init(),
+            window.supertokensUITOTP.init(),
+            window.supertokensUISession.init(),
         ],
     });
 }

--- a/boilerplate/frontend/shared/web-js/template.js
+++ b/boilerplate/frontend/shared/web-js/template.js
@@ -35,19 +35,19 @@ import Session from "supertokens-web-js/recipe/session";
 import Multitenancy from "supertokens-web-js/recipe/multitenancy";`,
 };
 export const uiRecipeInits = {
-    emailPassword: () => `(window as any).supertokensUIEmailPassword.init()`,
+    emailPassword: () => `window.supertokensUIEmailPassword.init()`,
     thirdParty: (providers) => {
         const providerInitMap = {
-            google: "(window as any).supertokensUIThirdParty.Google.init()",
-            github: "(window as any).supertokensUIThirdParty.Github.init()",
-            apple: "(window as any).supertokensUIThirdParty.Apple.init()",
-            twitter: "(window as any).supertokensUIThirdParty.Twitter.init()",
+            google: "window.supertokensUIThirdParty.Google.init()",
+            github: "window.supertokensUIThirdParty.Github.init()",
+            apple: "window.supertokensUIThirdParty.Apple.init()",
+            twitter: "window.supertokensUIThirdParty.Twitter.init()",
         };
         const providerInits = providers
             .map((p) => providerInitMap[p.id])
             .filter(Boolean)
             .join(",\n                        ");
-        return `(window as any).supertokensUIThirdParty.init({
+        return `window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
                         ${providerInits}
@@ -84,26 +84,26 @@ export const uiRecipeInits = {
         if (flowType) {
             initObj.push(`flowType: "${flowType}"`);
         }
-        return `(window as any).supertokensUIPasswordless.init({
+        return `window.supertokensUIPasswordless.init({
                 ${initObj.join(",\n                ")}
             })`;
     },
-    session: () => `(window as any).supertokensUISession.init()`,
+    session: () => `window.supertokensUISession.init()`,
     multiFactorAuth: (firstFactors, secondFactors) => {
         const firstFactorsStr = firstFactors
             ? firstFactors.map((f) => `"${f}"`).join(", ")
             : `"thirdparty", "emailpassword"`;
         if (secondFactors && secondFactors.length > 0) {
             const factorMapping = {
-                totp: "(window as any).supertokensUIMultiFactorAuth.FactorIds.TOTP",
-                "otp-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
-                "otp-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
-                "link-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
-                "link-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
+                totp: "window.supertokensUIMultiFactorAuth.FactorIds.TOTP",
+                "otp-email": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
+                "otp-phone": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
+                "link-email": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
+                "link-phone": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
             };
             const factorIds = secondFactors.map((factor) => factorMapping[factor] || `"${factor}"`).filter(Boolean);
             if (factorIds.length > 0) {
-                return `(window as any).supertokensUIMultiFactorAuth.init({
+                return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}],
         override: {
             functions: (originalImplementation: any) => ({
@@ -123,15 +123,15 @@ export const uiRecipeInits = {
     })`;
             }
         }
-        return `(window as any).supertokensUIMultiFactorAuth.init({
+        return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}]
     })`;
     },
-    emailVerification: (hasMFA) => `(window as any).supertokensUIEmailVerification.init({
+    emailVerification: (hasMFA) => `window.supertokensUIEmailVerification.init({
         mode: ${hasMFA ? '"OPTIONAL"' : '"REQUIRED"'}
     })`,
-    totp: () => `(window as any).supertokensUITOTP.init()`,
-    multitenancy: () => `(window as any).supertokensUIMultitenancy.init({
+    totp: () => `window.supertokensUITOTP.init()`,
+    multitenancy: () => `window.supertokensUIMultitenancy.init({
         override: {
             functions: (oI) => {
                 return {
@@ -266,7 +266,7 @@ ${getApiDomainFunc}
 ${getWebsiteDomainFunc}
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),

--- a/boilerplate/frontend/shared/web-js/template.ts
+++ b/boilerplate/frontend/shared/web-js/template.ts
@@ -49,13 +49,13 @@ import Multitenancy from "supertokens-web-js/recipe/multitenancy";`,
 } as const;
 
 export const uiRecipeInits = {
-    emailPassword: () => `(window as any).supertokensUIEmailPassword.init()`,
+    emailPassword: () => `window.supertokensUIEmailPassword.init()`,
     thirdParty: (providers: OAuthProvider[]) => {
         const providerInitMap: Record<string, string> = {
-            google: "(window as any).supertokensUIThirdParty.Google.init()",
-            github: "(window as any).supertokensUIThirdParty.Github.init()",
-            apple: "(window as any).supertokensUIThirdParty.Apple.init()",
-            twitter: "(window as any).supertokensUIThirdParty.Twitter.init()",
+            google: "window.supertokensUIThirdParty.Google.init()",
+            github: "window.supertokensUIThirdParty.Github.init()",
+            apple: "window.supertokensUIThirdParty.Apple.init()",
+            twitter: "window.supertokensUIThirdParty.Twitter.init()",
         };
 
         const providerInits = providers
@@ -63,7 +63,7 @@ export const uiRecipeInits = {
             .filter(Boolean)
             .join(",\n                        ");
 
-        return `(window as any).supertokensUIThirdParty.init({
+        return `window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
                         ${providerInits}
@@ -101,11 +101,11 @@ export const uiRecipeInits = {
             initObj.push(`flowType: "${flowType}"`);
         }
 
-        return `(window as any).supertokensUIPasswordless.init({
+        return `window.supertokensUIPasswordless.init({
                 ${initObj.join(",\n                ")}
             })`;
     },
-    session: () => `(window as any).supertokensUISession.init()`,
+    session: () => `window.supertokensUISession.init()`,
     multiFactorAuth: (firstFactors?: string[], secondFactors?: string[]) => {
         const firstFactorsStr = firstFactors
             ? firstFactors.map((f) => `"${f}"`).join(", ")
@@ -113,32 +113,32 @@ export const uiRecipeInits = {
 
         if (secondFactors && secondFactors.length > 0) {
             const factorMapping: Record<string, string> = {
-                totp: "(window as any).supertokensUIMultiFactorAuth.FactorIds.TOTP",
-                "otp-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
-                "otp-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
-                "link-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
-                "link-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
+                totp: "window.supertokensUIMultiFactorAuth.FactorIds.TOTP",
+                "otp-email": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
+                "otp-phone": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
+                "link-email": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
+                "link-phone": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
             };
 
             const factorIds = secondFactors.map((factor) => factorMapping[factor] || `"${factor}"`).filter(Boolean);
 
             if (factorIds.length > 0) {
-                return `(window as any).supertokensUIMultiFactorAuth.init({
+                return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}]
     })`;
             }
         }
 
-        return `(window as any).supertokensUIMultiFactorAuth.init({
+        return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}]
     })`;
     },
-    webauthn: () => `(window as any).supertokensUIWebAuthn.init(), (window as any).supertokensUISession.init(),`,
-    emailVerification: (hasMFA?: boolean) => `(window as any).supertokensUIEmailVerification.init({
+    webauthn: () => `window.supertokensUIWebAuthn.init(), window.supertokensUISession.init(),`,
+    emailVerification: (hasMFA?: boolean) => `window.supertokensUIEmailVerification.init({
         mode: ${hasMFA ? '"OPTIONAL"' : '"REQUIRED"'}
     })`,
-    totp: () => `(window as any).supertokensUITOTP.init()`,
-    multitenancy: () => `(window as any).supertokensUIMultitenancy.init({
+    totp: () => `window.supertokensUITOTP.init()`,
+    multitenancy: () => `window.supertokensUIMultitenancy.init({
         override: {
             functions: (oI: any) => {
                 return {
@@ -320,12 +320,64 @@ export function getWebsiteDomain() {
 
 ${imports}
 
+declare global {
+  interface Window {
+    supertokensUIInit: (
+      appId: string,
+      config: {
+        appInfo: {
+          websiteDomain: string;
+          apiDomain: string;
+          appName: string;
+          websiteBasePath: string;
+          apiBasePath: string;
+        };
+        recipeList: unknown[];
+        getRedirectionURL?: (context: { action: string }) => Promise<string | undefined>;
+      }
+    ) => void;
+
+    supertokensUIEmailPassword: { init: () => void };
+    supertokensUIThirdParty: {
+      Google: { init: () => void };
+      Github: { init: () => void };
+      Apple: { init: () => void };
+      Twitter: { init: () => void };
+      init: (config: { signInAndUpFeature: { providers: unknown[] } }) => void;
+    };
+    supertokensUIPasswordless: {
+      init: (config: { contactMethod: string; flowType?: string }) => void;
+    };
+    supertokensUISession: { init: () => void };
+    supertokensUIMultiFactorAuth: {
+      init: (config: { firstFactors: string[] }) => void;
+      FactorIds: {
+        TOTP: string;
+        OTP_EMAIL: string;
+        OTP_PHONE: string;
+        LINK_EMAIL: string;
+        LINK_PHONE: string;
+      };
+    };
+    supertokensUIWebAuthn: { init: () => void };
+    supertokensUIEmailVerification: { init: (config: { mode: "OPTIONAL" | "REQUIRED" }) => void };
+    supertokensUITOTP: { init: () => void };
+    supertokensUIMultitenancy: {
+      init: (config: {
+        override: {
+          functions: (original: Record<string, unknown>) => Record<string, unknown>;
+        };
+      }) => void;
+    };
+  }
+}
+
 const isMultitenancy = ${isMultitenancyInternal};
 ${getApiDomainFunc}
 ${getWebsiteDomainFunc}
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),

--- a/lib/build/boilerplate/frontend/shared/web-js/template.js
+++ b/lib/build/boilerplate/frontend/shared/web-js/template.js
@@ -37,19 +37,19 @@ import Session from "supertokens-web-js/recipe/session";
 import Multitenancy from "supertokens-web-js/recipe/multitenancy";`,
 };
 export const uiRecipeInits = {
-    emailPassword: () => `(window as any).supertokensUIEmailPassword.init()`,
+    emailPassword: () => `window.supertokensUIEmailPassword.init()`,
     thirdParty: (providers) => {
         const providerInitMap = {
-            google: "(window as any).supertokensUIThirdParty.Google.init()",
-            github: "(window as any).supertokensUIThirdParty.Github.init()",
-            apple: "(window as any).supertokensUIThirdParty.Apple.init()",
-            twitter: "(window as any).supertokensUIThirdParty.Twitter.init()",
+            google: "window.supertokensUIThirdParty.Google.init()",
+            github: "window.supertokensUIThirdParty.Github.init()",
+            apple: "window.supertokensUIThirdParty.Apple.init()",
+            twitter: "window.supertokensUIThirdParty.Twitter.init()",
         };
         const providerInits = providers
             .map((p) => providerInitMap[p.id])
             .filter(Boolean)
             .join(",\n                        ");
-        return `(window as any).supertokensUIThirdParty.init({
+        return `window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
                         ${providerInits}
@@ -82,40 +82,40 @@ export const uiRecipeInits = {
         if (flowType) {
             initObj.push(`flowType: "${flowType}"`);
         }
-        return `(window as any).supertokensUIPasswordless.init({
+        return `window.supertokensUIPasswordless.init({
                 ${initObj.join(",\n                ")}
             })`;
     },
-    session: () => `(window as any).supertokensUISession.init()`,
+    session: () => `window.supertokensUISession.init()`,
     multiFactorAuth: (firstFactors, secondFactors) => {
         const firstFactorsStr = firstFactors
             ? firstFactors.map((f) => `"${f}"`).join(", ")
             : `"thirdparty", "emailpassword"`;
         if (secondFactors && secondFactors.length > 0) {
             const factorMapping = {
-                totp: "(window as any).supertokensUIMultiFactorAuth.FactorIds.TOTP",
-                "otp-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
-                "otp-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
-                "link-email": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
-                "link-phone": "(window as any).supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
+                totp: "window.supertokensUIMultiFactorAuth.FactorIds.TOTP",
+                "otp-email": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL",
+                "otp-phone": "window.supertokensUIMultiFactorAuth.FactorIds.OTP_PHONE",
+                "link-email": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_EMAIL",
+                "link-phone": "window.supertokensUIMultiFactorAuth.FactorIds.LINK_PHONE",
             };
             const factorIds = secondFactors.map((factor) => factorMapping[factor] || `"${factor}"`).filter(Boolean);
             if (factorIds.length > 0) {
-                return `(window as any).supertokensUIMultiFactorAuth.init({
+                return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}]
     })`;
             }
         }
-        return `(window as any).supertokensUIMultiFactorAuth.init({
+        return `window.supertokensUIMultiFactorAuth.init({
         firstFactors: [${firstFactorsStr}]
     })`;
     },
-    webauthn: () => `(window as any).supertokensUIWebAuthn.init(), (window as any).supertokensUISession.init(),`,
-    emailVerification: (hasMFA) => `(window as any).supertokensUIEmailVerification.init({
+    webauthn: () => `window.supertokensUIWebAuthn.init(), window.supertokensUISession.init(),`,
+    emailVerification: (hasMFA) => `window.supertokensUIEmailVerification.init({
         mode: ${hasMFA ? '"OPTIONAL"' : '"REQUIRED"'}
     })`,
-    totp: () => `(window as any).supertokensUITOTP.init()`,
-    multitenancy: () => `(window as any).supertokensUIMultitenancy.init({
+    totp: () => `window.supertokensUITOTP.init()`,
+    multitenancy: () => `window.supertokensUIMultitenancy.init({
         override: {
             functions: (oI: any) => {
                 return {
@@ -274,12 +274,64 @@ export function getWebsiteDomain() {
 
 ${imports}
 
+declare global {
+  interface Window {
+    supertokensUIInit: (
+      appId: string,
+      config: {
+        appInfo: {
+          websiteDomain: string;
+          apiDomain: string;
+          appName: string;
+          websiteBasePath: string;
+          apiBasePath: string;
+        };
+        recipeList: unknown[];
+        getRedirectionURL?: (context: { action: string }) => Promise<string | undefined>;
+      }
+    ) => void;
+
+    supertokensUIEmailPassword: { init: () => void };
+    supertokensUIThirdParty: {
+      Google: { init: () => void };
+      Github: { init: () => void };
+      Apple: { init: () => void };
+      Twitter: { init: () => void };
+      init: (config: { signInAndUpFeature: { providers: unknown[] } }) => void;
+    };
+    supertokensUIPasswordless: {
+      init: (config: { contactMethod: string; flowType?: string }) => void;
+    };
+    supertokensUISession: { init: () => void };
+    supertokensUIMultiFactorAuth: {
+      init: (config: { firstFactors: string[] }) => void;
+      FactorIds: {
+        TOTP: string;
+        OTP_EMAIL: string;
+        OTP_PHONE: string;
+        LINK_EMAIL: string;
+        LINK_PHONE: string;
+      };
+    };
+    supertokensUIWebAuthn: { init: () => void };
+    supertokensUIEmailVerification: { init: (config: { mode: "OPTIONAL" | "REQUIRED" }) => void };
+    supertokensUITOTP: { init: () => void };
+    supertokensUIMultitenancy: {
+      init: (config: {
+        override: {
+          functions: (original: Record<string, unknown>) => Record<string, unknown>;
+        };
+      }) => void;
+    };
+  }
+}
+
 const isMultitenancy = ${isMultitenancyInternal};
 ${getApiDomainFunc}
 ${getWebsiteDomainFunc}
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),

--- a/tests/__snapshots__/webjs-template.test.ts.snap
+++ b/tests/__snapshots__/webjs-template.test.ts.snap
@@ -17,7 +17,7 @@ export function getWebsiteDomain() {
 }
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),
@@ -26,9 +26,9 @@ export function initSuperTokensUI() {
             apiBasePath: "/auth",
         },
         recipeList: [
-            (window as any).supertokensUISession.init(),
-            (window as any).supertokensUIEmailPassword.init(),
-            (window as any).supertokensUIPasswordless.init({
+            window.supertokensUISession.init(),
+            window.supertokensUIEmailPassword.init(),
+            window.supertokensUIPasswordless.init({
                 contactMethod: "EMAIL_OR_PHONE",
                 flowType: "USER_INPUT_CODE"
             })
@@ -69,7 +69,7 @@ export function getWebsiteDomain() {
 }
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),
@@ -78,23 +78,23 @@ export function initSuperTokensUI() {
             apiBasePath: "/auth",
         },
         recipeList: [
-            (window as any).supertokensUISession.init(),
-            (window as any).supertokensUIEmailPassword.init(),
-            (window as any).supertokensUIThirdParty.init({
+            window.supertokensUISession.init(),
+            window.supertokensUIEmailPassword.init(),
+            window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
-                        (window as any).supertokensUIThirdParty.Google.init(),
-                        (window as any).supertokensUIThirdParty.Github.init(),
-                        (window as any).supertokensUIThirdParty.Apple.init(),
-                        (window as any).supertokensUIThirdParty.Twitter.init()
+                        window.supertokensUIThirdParty.Google.init(),
+                        window.supertokensUIThirdParty.Github.init(),
+                        window.supertokensUIThirdParty.Apple.init(),
+                        window.supertokensUIThirdParty.Twitter.init()
                     ],
                 },
             }),
-            (window as any).supertokensUIPasswordless.init({
+            window.supertokensUIPasswordless.init({
                 contactMethod: "EMAIL",
                 flowType: "USER_INPUT_CODE"
             }),
-            (window as any).supertokensUIMultiFactorAuth.init({
+            window.supertokensUIMultiFactorAuth.init({
         firstFactors: ["emailpassword", "thirdparty"],
         override: {
             functions: (originalImplementation: any) => ({
@@ -102,17 +102,17 @@ export function initSuperTokensUI() {
                 getMFARequirementsForAuth: () => [
                     {
                         oneOf: [
-                            (window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL
+                            window.supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL
                         ],
                     },
                 ],
                 getRequiredSecondaryFactorsForUser: async () => {
-                    return [(window as any).supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL];
+                    return [window.supertokensUIMultiFactorAuth.FactorIds.OTP_EMAIL];
                 },
             }),
         }
     }),
-            (window as any).supertokensUIEmailVerification.init({
+            window.supertokensUIEmailVerification.init({
         mode: "OPTIONAL"
     })
         ],
@@ -150,7 +150,7 @@ export function getWebsiteDomain() {
 }
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),
@@ -159,8 +159,8 @@ export function initSuperTokensUI() {
             apiBasePath: "/auth",
         },
         recipeList: [
-            (window as any).supertokensUISession.init(),
-            (window as any).supertokensUIEmailPassword.init()
+            window.supertokensUISession.init(),
+            window.supertokensUIEmailPassword.init()
         ],
     });
 }
@@ -196,7 +196,7 @@ export function getWebsiteDomain() {
 }
 
 export function initSuperTokensUI() {
-    (window as any).supertokensUIInit("supertokensui", {
+    window.supertokensUIInit("supertokensui", {
         appInfo: {
             websiteDomain: getWebsiteDomain(),
             apiDomain: getApiDomain(),
@@ -205,14 +205,14 @@ export function initSuperTokensUI() {
             apiBasePath: "/auth",
         },
         recipeList: [
-            (window as any).supertokensUISession.init(),
-            (window as any).supertokensUIThirdParty.init({
+            window.supertokensUISession.init(),
+            window.supertokensUIThirdParty.init({
                 signInAndUpFeature: {
                     providers: [
-                        (window as any).supertokensUIThirdParty.Google.init(),
-                        (window as any).supertokensUIThirdParty.Github.init(),
-                        (window as any).supertokensUIThirdParty.Apple.init(),
-                        (window as any).supertokensUIThirdParty.Twitter.init()
+                        window.supertokensUIThirdParty.Google.init(),
+                        window.supertokensUIThirdParty.Github.init(),
+                        window.supertokensUIThirdParty.Apple.init(),
+                        window.supertokensUIThirdParty.Twitter.init()
                     ],
                 },
             })


### PR DESCRIPTION
## Summary of change

Remove `window as any` cast by declaring a window global

## Related issues

-   [issue](https://github.com/supertokens/create-supertokens-app/issues/151)

## Test plan

-   [ ] If added a new boilerplate
    -   I tested the new boilerplate by running the CLI locally
    -   I tested that the boilerplate is created and works correctly when using command line flags (`--recipe=...` for example)
-   [ ] If added a new recipe, frontend or backend
    -   I tested that the newly added option is usable by passing command line flags (`--recipe=...` for example)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If added a new recipe, I also modified types to include the new recipe in `Recipe` and `allRecipes`
-   [ ] If added a new frontend, I also modified types to include the new frontend in `SupportedFrontends` and `allFrontends` if required
-   [ ] If added a new backend, I also modified types to include the new backend in `SupportedBackends` and `allBackends` if required

